### PR TITLE
Use node-glob's `ignore` option, massive perf improvement regarding negative globs

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -10,16 +10,12 @@ var BENCH_DIR = 'bench';
 var runners = [{
 	name: 'globby async (working directory)',
 	run: function (patterns, cb) {
-		setImmediate(function() {
-			globby(patterns, cb);
-		})
+		setImmediate(globby, patterns, cb);
 	}
 }, {
 	name: 'globby async (upstream/master)',
 	run: function (patterns, cb) {
-		setImmediate(function() {
-			globbyMaster(patterns, cb);
-		})
+		setImmediate(globbyMaster, patterns, cb);
 	}
 }, {
 	name: 'globby sync (working directory)',

--- a/bench.js
+++ b/bench.js
@@ -34,11 +34,11 @@ var runners = [{
 	}
 }];
 var benchs = [{
-	name: 'negative globs (100 negated paths)',
+	name: 'negative globs (some files inside dir)',
 	patterns: ['a/*', '!a/c*']
 }, {
-	name: 'negative globs (500 negated paths)',
-	patterns: ['a/*', '!a/*']
+	name: 'negative globs (whole dir)',
+	patterns: ['a/*', '!a/**']
 }, {
 	name: 'multiple positive globs',
 	patterns: ['a/*', 'b/*']

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "array-union": "^1.0.1",
     "async": "^0.9.0",
-    "glob": "^4.0.2",
+    "glob": "vegetableman/node-glob#fix-ignore-branch",
     "minimatch": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
   "dependencies": {
     "array-union": "^1.0.1",
     "async": "^0.9.0",
-    "glob": "vegetableman/node-glob#fix-ignore-branch",
-    "minimatch": "^2.0.1"
+    "glob": "vegetableman/node-glob#fix-ignore-branch"
   },
   "devDependencies": {
     "glob-stream": "wearefractal/glob-stream#master",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "array-union": "^1.0.1",
     "async": "^0.9.0",
-    "glob": "vegetableman/node-glob#fix-ignore-branch",
+    "glob": "^4.4.0",
     "object-assign": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "dependencies": {
     "array-union": "^1.0.1",
     "async": "^0.9.0",
-    "glob": "vegetableman/node-glob#fix-ignore-branch"
+    "glob": "vegetableman/node-glob#fix-ignore-branch",
+    "object-assign": "^2.0.0"
   },
   "devDependencies": {
     "glob-stream": "wearefractal/glob-stream#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globby",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Extends `glob` with support for multiple patterns",
   "license": "MIT",
   "repository": "sindresorhus/globby",

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ it('should not mutate the options object - async', function(cb) {
 	globby(['*.tmp', '!b.tmp'], opts, function (err, paths) {
 		assert(!err, err);
 		assert.strictEqual(opts.ignore, ignore); // same reference
-		assert.deepEqual(opts.ignore, ignore); // same contents
+		assert.deepEqual(ignore, []); // same contents
 		cb();
 	});
 });
@@ -75,5 +75,5 @@ it('should not mutate the options object - sync', function() {
 	var opts = { ignore: ignore };
 	globby.sync(['*.tmp', '!b.tmp'], opts);
 	assert.strictEqual(opts.ignore, ignore); // same reference
-	assert.deepEqual(opts.ignore, ignore); // same contents
+	assert.deepEqual(ignore, []); // same contents
 });

--- a/test.js
+++ b/test.js
@@ -60,20 +60,12 @@ it('cwd option', function () {
 });
 
 it('should not mutate the options object - async', function(cb) {
-	var ignore = [];
-	var opts = { ignore: ignore };
-	globby(['*.tmp', '!b.tmp'], opts, function (err, paths) {
+	globby(['*.tmp', '!b.tmp'], Object.freeze({ ignore: Object.freeze([]) }), function (err, paths) {
 		assert(!err, err);
-		assert.strictEqual(opts.ignore, ignore); // same reference
-		assert.deepEqual(ignore, []); // same contents
 		cb();
 	});
 });
 
 it('should not mutate the options object - sync', function() {
-	var ignore = [];
-	var opts = { ignore: ignore };
-	globby.sync(['*.tmp', '!b.tmp'], opts);
-	assert.strictEqual(opts.ignore, ignore); // same reference
-	assert.deepEqual(ignore, []); // same contents
+	globby.sync(['*.tmp', '!b.tmp'], Object.freeze({ ignore: Object.freeze([]) }));
 });

--- a/test.js
+++ b/test.js
@@ -58,3 +58,22 @@ it('cwd option', function () {
 	assert.deepEqual(globby.sync(['a.tmp', '*.tmp', '!{c,d,e}.tmp'], {cwd: cwd}), ['a.tmp', 'b.tmp']);
 	process.chdir(cwd);
 });
+
+it('should not mutate the options object - async', function(cb) {
+	var ignore = [];
+	var opts = { ignore: ignore };
+	globby(['*.tmp', '!b.tmp'], opts, function (err, paths) {
+		assert(!err, err);
+		assert.strictEqual(opts.ignore, ignore); // same reference
+		assert.deepEqual(opts.ignore, ignore); // same contents
+		cb();
+	});
+});
+
+it('should not mutate the options object - sync', function() {
+	var ignore = [];
+	var opts = { ignore: ignore };
+	globby.sync(['*.tmp', '!b.tmp'], opts);
+	assert.strictEqual(opts.ignore, ignore); // same reference
+	assert.deepEqual(opts.ignore, ignore); // same contents
+});


### PR DESCRIPTION
Benchmark results on my main dev machine:

```
                      negative globs (whole dir)
          10,296 op/s » globby async (working directory)
             100 op/s » globby async (upstream/master)
          20,547 op/s » globby sync (working directory)
             105 op/s » globby sync (upstream/master)
              66 op/s » glob-stream
```

@sindresorhus PTAL.