### PR TITLE
Use a Promise API instead of a callback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
   "dependencies": {
     "array-union": "^1.0.1",
     "arrify": "^1.0.0",
-    "async": "^1.2.1",
     "glob": "^5.0.3",
-    "object-assign": "^3.0.0"
+    "object-assign": "^3.0.0",
+    "pify": "^1.0.0",
+    "pinkie-promise": "^1.0.0"
   },
   "devDependencies": {
     "glob-stream": "wearefractal/glob-stream#master",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # globby [![Build Status](https://travis-ci.org/sindresorhus/globby.svg?branch=master)](https://travis-ci.org/sindresorhus/globby)
 
-> Extends [glob](https://github.com/isaacs/node-glob) with support for multiple patterns
+> Extends [glob](https://github.com/isaacs/node-glob) with support for multiple patterns and exposes a Promise API
 
 
 ## Install
@@ -30,7 +30,7 @@ globby(['*', '!cake'], function (err, paths) {
 
 ## API
 
-### globby(patterns, [options], callback)
+### globby(patterns, [options])
 
 ### globby.sync(patterns, [options])
 
@@ -47,8 +47,8 @@ Type: `object`
 
 See the node-glob [options](https://github.com/isaacs/node-glob#options).
 
-#### callback(err, paths)
-
+`globby.sync` synchronously returns an array of paths matching the glob expression.
+`globby` returns a Promise object that resolves to an array of matching paths or is rejected with an error.
 
 ## Globbing patterns
 

--- a/test.js
+++ b/test.js
@@ -22,27 +22,21 @@ after(function () {
 	fixture.forEach(fs.unlinkSync.bind(fs));
 });
 
-it('should glob - async', function (cb) {
-	globby('*.tmp', function (err, paths) {
-		assert(!err, err);
+it('should glob - async', function () {
+	return globby('*.tmp').then(function (paths) {
 		assert.deepEqual(paths, ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
-		cb();
 	});
 });
 
-it('should glob with multiple patterns - async', function (cb) {
-	globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp'], function (err, paths) {
-		assert(!err, err);
+it('should glob with multiple patterns - async', function () {
+	return globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']).then(function (paths) {
 		assert.deepEqual(paths, ['a.tmp', 'b.tmp']);
-		cb();
 	});
 });
 
-it('should respect patterns order - async', function (cb) {
-	globby(['!*.tmp', 'a.tmp'], function (err, paths) {
-		assert(!err, err);
+it('should respect patterns order - async', function () {
+	return globby(['!*.tmp', 'a.tmp']).then(function (paths) {
 		assert.deepEqual(paths, ['a.tmp']);
-		cb();
 	});
 });
 
@@ -52,6 +46,16 @@ it('should glob - sync', function () {
 	assert.deepEqual(globby.sync(['!*.tmp', 'a.tmp']), ['a.tmp']);
 });
 
+it('should return [] for all negative patterns - sync', function () {
+	assert.deepEqual(globby.sync(['!a.tmp', '!b.tmp']), []);
+})
+
+it('should return [] for all negative patterns - async', function () {
+	return globby(['!a.tmp', '!b.tmp']).then(function (paths) {
+		assert.deepEqual(paths, []);
+	});
+})
+
 it('cwd option', function () {
 	process.chdir('tmp');
 	assert.deepEqual(globby.sync('*.tmp', {cwd: cwd}), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
@@ -59,11 +63,8 @@ it('cwd option', function () {
 	process.chdir(cwd);
 });
 
-it('should not mutate the options object - async', function (cb) {
-	globby(['*.tmp', '!b.tmp'], Object.freeze({ignore: Object.freeze([])}), function (err, paths) {
-		assert(!err, err);
-		cb();
-	});
+it('should not mutate the options object - async', function () {
+	return globby(['*.tmp', '!b.tmp'], Object.freeze({ignore: Object.freeze([])}));
 });
 
 it('should not mutate the options object - sync', function () {


### PR DESCRIPTION
As discussed in sindresorhus/del#29, here's a Promise implementation for globby. I followed the same direction as with that PR, removing the callback interface. I don't mind adding it back though.

Using Promises alone I was able to get rid of the `async` dependency and clean up the implementation quite a bit. ~~I did have to add a small wrapper around `glob` inline, but considered a [ponyfill-compatible, standalone version of denodeify](https://github.com/valeriangalliat/es6-denodeify). There's also [ahmadnassri/glob-promise](https://github.com/ahmadnassri/glob-promise), but it won't take an arbitrary Promise constructor and would force users to have a global one.~~ Using `pify`.

Let me know where to go from here. Totally happy to adapt.