### PR TITLE
recursive option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,14 @@ See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).
 
 Type: `object`
 
-See the `node-glob` [options](https://github.com/isaacs/node-glob#options).
+Options are passed to [node-glob](https://github.com/isaacs/node-glob#options).
 
+##### recursive
+
+Type: `boolean`
+Default: `false`
+
+Glob directories recursively.
 
 ## Globbing patterns
 


### PR DESCRIPTION
A `recursive` option for https://github.com/sindresorhus/cpy/issues/10#issuecomment-198407548.

The procedure would be as follows:
1. glob patterns as usual
2. for each `path` in the result, execute an additional glob: `var paths = glob(path + '{,/**}', opts)`
   * if `path` is a file, then `paths` equals to `[path]`
   * if `path` is a directory, then `paths` contains `path` and all its files and folders with respect to `opts` (especially: `ignore`, `dot` and `follow`)
