### PR TITLE
Expose generateGlobTasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,63 +6,52 @@ var glob = require('glob');
 var arrify = require('arrify');
 var pify = require('pify');
 
-function sortPatterns(patterns) {
+var globP = pify(glob, Promise).bind(glob);
+
+function isNegative(pattern) {
+	return pattern[0] === '!';
+}
+
+function generateGlobTasks(patterns, opts) {
+	var globTasks = [];
+
 	patterns = arrify(patterns);
+	opts = objectAssign({ignore: []}, opts);
 
-	var positives = [];
-	var negatives = [];
+	patterns.forEach(function (pattern, i) {
+		if (isNegative(pattern)) {
+			return;
+		}
 
-	patterns.forEach(function (pattern, index) {
-		var isNegative = pattern[0] === '!';
-		(isNegative ? negatives : positives).push({
-			index: index,
-			pattern: isNegative ? pattern.slice(1) : pattern
+		var ignore = patterns.slice(i).filter(isNegative).map(function (pattern) {
+			return pattern.slice(1);
+		});
+
+		globTasks.push({
+			pattern: pattern,
+			opts: objectAssign({}, opts, {
+				ignore: opts.ignore.concat(ignore)
+			})
 		});
 	});
 
-	return {
-		positives: positives,
-		negatives: negatives
-	};
-}
-
-function setIgnore(opts, negatives, positiveIndex) {
-	opts = objectAssign({}, opts);
-
-	var negativePatterns = negatives.filter(function (negative) {
-		return negative.index > positiveIndex;
-	}).map(function (negative) {
-		return negative.pattern;
-	});
-
-	opts.ignore = (opts.ignore || []).concat(negativePatterns);
-	return opts;
+	return globTasks;
 }
 
 module.exports = function (patterns, opts) {
-	var sortedPatterns = sortPatterns(patterns);
-	opts = opts || {};
+	var globTasks = generateGlobTasks(patterns, opts);
 
-	if (sortedPatterns.positives.length === 0) {
-		return Promise.resolve([]);
-	}
-
-	return Promise.all(sortedPatterns.positives.map(function (positive) {
-		var globOpts = setIgnore(opts, sortedPatterns.negatives, positive.index);
-		return pify(glob, Promise)(positive.pattern, globOpts);
+	return Promise.all(globTasks.map(function (task) {
+		return globP(task.pattern, task.opts);
 	})).then(function (paths) {
 		return arrayUnion.apply(null, paths);
 	});
 };
 
 module.exports.sync = function (patterns, opts) {
-	var sortedPatterns = sortPatterns(patterns);
+	var globTasks = generateGlobTasks(patterns, opts);
 
-	if (sortedPatterns.positives.length === 0) {
-		return [];
-	}
-
-	return sortedPatterns.positives.reduce(function (ret, positive) {
-		return arrayUnion(ret, glob.sync(positive.pattern, setIgnore(opts, sortedPatterns.negatives, positive.index)));
+	return globTasks.reduce(function (matches, task) {
+		return arrayUnion(matches, glob.sync(task.pattern, task.opts));
 	}, []);
 };

--- a/index.js
+++ b/index.js
@@ -55,3 +55,5 @@ module.exports.sync = function (patterns, opts) {
 		return arrayUnion(matches, glob.sync(task.pattern, task.opts));
 	}, []);
 };
+
+module.exports.generateGlobTasks = generateGlobTasks;

--- a/test.js
+++ b/test.js
@@ -70,3 +70,11 @@ it('should not mutate the options object - async', function () {
 it('should not mutate the options object - sync', function () {
 	globby.sync(['*.tmp', '!b.tmp'], Object.freeze({ignore: Object.freeze([])}));
 });
+
+it('should expose generateGlobTasks', function () {
+	var tasks = globby.generateGlobTasks(['*.tmp', '!b.tmp'], {ignore: ['c.tmp']});
+
+	assert.strictEqual(tasks.length, 1);
+	assert.strictEqual(tasks[0].pattern, '*.tmp');
+	assert.deepEqual(tasks[0].opts.ignore, ['c.tmp', 'b.tmp']);
+});


### PR DESCRIPTION
I've done some clean up and unified the sync and async implementations.

The main purpose is to expose the new `generateGlobTasks` function, which I want to use in `cpy` for the `recursive` option, so that I don't need to re-implement it there.

@UltCombo: I know you have little time, but I've changed mostly code you have introduced. I would be very happy if you will find some time to review it.

@sindresorhus: Maybe `generateGlobTasks` should be extracted into its own package, but I'm not sure  how useful this would be.