### PR TITLE
Share filesystem caches between tasks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,13 @@ function generateGlobTasks(patterns, opts) {
 	var globTasks = [];
 
 	patterns = arrify(patterns);
-	opts = objectAssign({ignore: []}, opts);
+	opts = objectAssign({
+		cache: Object.create(null),
+		statCache: Object.create(null),
+		realpathCache: Object.create(null),
+		symlinks: Object.create(null),
+		ignore: []
+	}, opts);
 
 	patterns.forEach(function (pattern, i) {
 		if (isNegative(pattern)) {


### PR DESCRIPTION
Should improve performance.

From the [`node-glob` docs](https://github.com/isaacs/node-glob#options):

> At the very least, you may pass in shared symlinks, statCache, realpathCache, and cache options, so that parallel glob operations will be sped up by sharing information about the filesystem.