### PR TITLE
Support negated ignores

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function generateGlobTasks(patterns, opts) {
 		ignore = opts.ignore.concat(ignore);
 
 		// Convert negated ignores into positive patterns
-		ignore.forEach(function(ign) {
+		ignore.forEach(function (ign) {
 			if (!isNegative(ign)) {
 				return;
 			}
@@ -57,8 +57,8 @@ function generateGlobTasks(patterns, opts) {
 		});
 
 		// Remove negated ignores from array
-		ignore = ignore.filter(function(ign) {
-			return !isNegative(ign)
+		ignore = ignore.filter(function (ign) {
+			return !isNegative(ign);
 		});
 
 		globTasks.push({

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ module.exports = function (patterns, opts) {
 	} catch (err) {
 		return Promise.reject(err);
 	}
+
 	return Promise.all(globTasks.map(function (task) {
 		return globP(task.pattern, task.opts);
 	})).then(function (paths) {

--- a/index.js
+++ b/index.js
@@ -43,11 +43,26 @@ function generateGlobTasks(patterns, opts) {
 		var ignore = patterns.slice(i).filter(isNegative).map(function (pattern) {
 			return pattern.slice(1);
 		});
+		ignore = opts.ignore.concat(ignore);
+
+		// Convert negated ignores into positive patterns
+		ignore.forEach(ign => {
+			if (!isNegative(ign)) {
+				return;
+			}
+			globTasks.push({
+				pattern: ign.slice(1),
+				opts: objectAssign({}, opts, {ignore: []})
+			});
+		});
+
+		// Remove negated ignores from array
+		ignore = ignore.filter(ign => !isNegative(ign));
 
 		globTasks.push({
 			pattern: pattern,
 			opts: objectAssign({}, opts, {
-				ignore: opts.ignore.concat(ignore)
+				ignore: ignore
 			})
 		});
 	});

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function generateGlobTasks(patterns, opts) {
 		ignore = opts.ignore.concat(ignore);
 
 		// Convert negated ignores into positive patterns
-		ignore.forEach(ign => {
+		ignore.forEach(function(ign) {
 			if (!isNegative(ign)) {
 				return;
 			}
@@ -57,7 +57,9 @@ function generateGlobTasks(patterns, opts) {
 		});
 
 		// Remove negated ignores from array
-		ignore = ignore.filter(ign => !isNegative(ign));
+		ignore = ignore.filter(function(ign) {
+			return !isNegative(ign)
+		});
 
 		globTasks.push({
 			pattern: pattern,

--- a/index.js
+++ b/index.js
@@ -78,7 +78,6 @@ module.exports = function (patterns, opts) {
 	} catch (err) {
 		return Promise.reject(err);
 	}
-
 	return Promise.all(globTasks.map(function (task) {
 		return globP(task.pattern, task.opts);
 	})).then(function (paths) {

--- a/test.js
+++ b/test.js
@@ -70,6 +70,14 @@ test('expose generateGlobTasks', t => {
 	t.deepEqual(tasks[0].opts.ignore, ['c.tmp', 'b.tmp']);
 });
 
+test(`ignore option`, async t => {
+	t.deepEqual(await m('*.tmp', {ignore: ['e.tmp']}), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp']);
+});
+
+test(`un-ignore negated rules in ignore option`, async t => {
+	t.deepEqual(await m('*.tmp', {ignore: ['*.tmp', '!e.tmp']}), ['e.tmp']);
+});
+
 // rejected for being an invalid pattern
 [
 	{},


### PR DESCRIPTION
This PR changes the behaviour so that entries in the `ignore` options that start with a `!` don't ignored. This is useful if you want to pass a list from `.gitignore` to the `ignore` option (as you do in `xo`).

<hr>

Example file structure:

```
├── a.js
└─── b
    ├── c.js
    └── d.js
```

Example `.gitignore`

```
b/*
!b/c.js
```

Computing which files would be added to Git:

``` js
await globby(`**/*`, {ignore: ['b/*', '!b/c.js']})
// => before: []
// => after: ['a.js', 'b/c.js']
```

Related `xo` issue: https://github.com/sindresorhus/xo/issues/154
