### PR TITLE
Fix broken link to multimatch tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Just a quick overview.
 - `{}` allows for a comma-separated list of "or" expressions
 - `!` at the beginning of a pattern will negate the match
 
-[Various patterns and expected matches.](https://github.com/sindresorhus/multimatch/blob/master/test.js)
+[Various patterns and expected matches.](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 
 
 ## Related


### PR DESCRIPTION
Multimatch tests are nested in a `test` dir.