### PR TITLE
Add `fast-glob` to benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const rimraf = require('rimraf');
 const globbyMaster = require('globby');
 const gs = require('glob-stream');
+const fastGlob = require('fast-glob');
 const globby = require('.');
 
 const BENCH_DIR = 'bench';
@@ -32,6 +33,16 @@ const runners = [{
 	name: 'glob-stream',
 	run: (patterns, cb) => {
 		gs(patterns).on('data', () => {}).on('end', cb);
+	}
+}, {
+	name: 'fast-glob async',
+	run: (patterns, cb) => {
+		fastGlob(patterns).then(cb.bind(null, null), cb);
+	}
+}, {
+	name: 'fast-glob sync',
+	run: patterns => {
+		fastGlob.sync(patterns);
 	}
 }];
 const benchs = [{

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "bench": "npm update glob-stream && matcha bench.js",
+    "bench": "npm update glob-stream fast-glob && matcha bench.js",
     "test": "xo && ava"
   },
   "files": [
@@ -62,7 +62,8 @@
   },
   "devDependencies": {
     "ava": "*",
-    "glob-stream": "gulpjs/glob-stream#master",
+    "fast-glob": "^1.0.1",
+    "glob-stream": "github:gulpjs/glob-stream#master",
     "globby": "sindresorhus/globby#master",
     "matcha": "^0.7.0",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
In a step towards fixing #50, this might be useful to have. Currently it looks like `fast-glob` is faster than `globby`.