### PR TITLE
Add gitignoreName option

### DIFF
--- a/fixtures/otherignore/.otherignore
+++ b/fixtures/otherignore/.otherignore
@@ -1,0 +1,2 @@
+foo.js
+!bar.js

--- a/fixtures/otherignore/bar.js
+++ b/fixtures/otherignore/bar.js
@@ -1,0 +1,6 @@
+import test from 'ava'
+import fn from '..'
+
+test(t => {
+   t.is(fn('foo'), fn('foobar'))
+})

--- a/fixtures/otherignore/foo.js
+++ b/fixtures/otherignore/foo.js
@@ -1,0 +1,6 @@
+import test from 'ava'
+import fn from '..'
+
+test(t => {
+   t.is(fn('foo'), fn('foobar'))
+})

--- a/gitignore.js
+++ b/gitignore.js
@@ -66,13 +66,18 @@ const normalizeOpts = opts => {
 	opts = opts || {};
 	const ignore = opts.ignore || [];
 	const cwd = opts.cwd || process.cwd();
-	return {ignore, cwd};
+	const filename = opts.filename || '.gitignore';
+	return {ignore, cwd, filename};
+};
+
+const getGitIgnoreGlob = filename => {
+	return path.join('**', filename);
 };
 
 module.exports = o => {
 	const opts = normalizeOpts(o);
 
-	return globP('**/.gitignore', {ignore: opts.ignore, cwd: opts.cwd})
+	return globP(getGitIgnoreGlob(opts.filename), {ignore: opts.ignore, cwd: opts.cwd})
 		.then(paths => Promise.all(paths.map(file => getFile(file, opts.cwd))))
 		.then(files => reduceIgnore(files))
 		.then(ignores => getIsIgnoredPredecate(ignores, opts.cwd));
@@ -81,7 +86,7 @@ module.exports = o => {
 module.exports.sync = o => {
 	const opts = normalizeOpts(o);
 
-	const paths = glob.sync('**/.gitignore', {ignore: opts.ignore, cwd: opts.cwd});
+	const paths = glob.sync(getGitIgnoreGlob(opts.filename), {ignore: opts.ignore, cwd: opts.cwd});
 	const files = paths.map(file => getFileSync(file, opts.cwd));
 	const ignores = reduceIgnore(files);
 	return getIsIgnoredPredecate(ignores, opts.cwd);

--- a/gitignore.test.js
+++ b/gitignore.test.js
@@ -38,6 +38,24 @@ test('ignore ignored .gitignore - sync', t => {
 	t.deepEqual(actual, expected);
 });
 
+test('use other ignore file', async t => {
+	const cwd = path.join(__dirname, 'fixtures/otherignore');
+	const filename = '.otherignore';
+	const isIgnored = await gitignore({cwd, filename});
+	const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+	const expected = ['bar.js'];
+	t.deepEqual(actual, expected);
+});
+
+test('use other ignore file - sync', t => {
+	const cwd = path.join(__dirname, 'fixtures/otherignore');
+	const filename = '.otherignore';
+	const isIgnored = gitignore.sync({cwd, filename});
+	const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+	const expected = ['bar.js'];
+	t.deepEqual(actual, expected);
+});
+
 test('negative gitignore', async t => {
 	const cwd = path.join(__dirname, 'fixtures/negative');
 	const isIgnored = await gitignore({cwd});

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = (patterns, opts) => {
 	const getFilter = () => {
 		return Promise.resolve(
 			opts && opts.gitignore ?
-				gitignore({cwd: opts.cwd, ignore: opts.ignore}) :
+				gitignore({cwd: opts.cwd, ignore: opts.ignore, filename: opts.gitignoreName}) :
 				DEFAULT_FILTER
 		);
 	};
@@ -105,7 +105,7 @@ module.exports.sync = (patterns, opts) => {
 
 	const getFilter = () => {
 		return opts && opts.gitignore ?
-			gitignore.sync({cwd: opts.cwd, ignore: opts.ignore}) :
+			gitignore.sync({cwd: opts.cwd, ignore: opts.ignore, filename: opts.gitignoreName}) :
 			DEFAULT_FILTER;
 	};
 

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,13 @@ Default: `false`
 
 Respect ignore patterns in `.gitignore` files that apply to the globbed files.
 
+##### gitignoreName
+
+Type: `string`<br>
+Default: `.gitignore`
+
+The file name to look for `.gitignore` file when applying ignore patterns to the globbed files.
+
 ### globby.sync(patterns, [options])
 
 Returns an `Array` of matching paths.

--- a/test.js
+++ b/test.js
@@ -174,6 +174,16 @@ test('respects gitignore option true - sync', t => {
 	t.false(actual.indexOf('node_modules') > -1);
 });
 
+test('respects other ignore option', async t => {
+	const actual = await m('fixtures/otherignore/*', {gitignore: true, gitignoreName: '.otherignore', nodir: false});
+	t.false(actual.indexOf('fixtures/otherignore/foo.js') > -1);
+});
+
+test('respects other ignore option - sync', t => {
+	const actual = m.sync('fixtures/otherignore/*', {gitignore: true, gitignoreName: '.otherignore', nodir: false});
+	t.false(actual.indexOf('fixtures/otherignore/foo.js') > -1);
+});
+
 test('respects gitignore option false', async t => {
 	const actual = await m('*', {gitignore: false, nodir: false});
 	t.true(actual.indexOf('node_modules') > -1);


### PR DESCRIPTION
This new option allows non-git tools to override the file name
of the .gitignore file when applying ignore patterns to globbed files.

The default is still `.gitignore` so the new option is compatible with
existing behavior.