### PR TITLE
Expand directories in ignore option

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ const generateGlobTasks = (patterns, taskOpts) => {
 		nodir: true
 	}, taskOpts);
 
+	if (taskOpts.expandDirectories) {
+		taskOpts.ignore = dirGlob.sync(taskOpts.ignore);
+	}
+
 	patterns.forEach((pattern, i) => {
 		if (isNegative(pattern)) {
 			return;

--- a/test.js
+++ b/test.js
@@ -109,6 +109,17 @@ test('expandDirectories option', t => {
 	}), ['tmp/a.tmp']);
 });
 
+test('expandDirectories and ignores option', t => {
+	t.deepEqual(m.sync('tmp', {
+		ignore: ['tmp']
+	}), []);
+
+	t.deepEqual(m.sync('tmp/**', {
+		expandDirectories: false,
+		ignore: ['tmp']
+	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
+});
+
 test('expandDirectories:true and nodir:true option', t => {
 	t.deepEqual(m.sync('tmp', {nodir: true}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 	t.deepEqual(m.sync('tmp', {nodir: false}), ['tmp', 'tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);


### PR DESCRIPTION
Fixes #62 

I feel weird about using `dirGlob.sync`, but this seemed to be the simplest way to do it without having to refactor some other stuff.