### PR TITLE
Introduce shallow gitignore parsing for better performance

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -30,6 +30,26 @@ const runners = [{
 		globbyMaster.sync(patterns);
 	}
 }, {
+	name: 'globby async gitignore (working directory)',
+	run: (patterns, cb) => {
+		globby(patterns, {gitignore: true}).then(cb.bind(null, null), cb);
+	}
+}, {
+	name: 'globby async gitignore (upstream/master)',
+	run: (patterns, cb) => {
+		globbyMaster(patterns, {gitignore: true}).then(cb.bind(null, null), cb);
+	}
+}, {
+	name: 'globby sync gitignore (working directory)',
+	run: patterns => {
+		globby.sync(patterns, {gitignore: true});
+	}
+}, {
+	name: 'globby sync gitignore (upstream/master)',
+	run: patterns => {
+		globbyMaster.sync(patterns, {gitignore: true});
+	}
+}, {
 	name: 'glob-stream',
 	run: (patterns, cb) => {
 		gs(patterns).on('data', () => {}).on('end', cb);
@@ -53,7 +73,7 @@ const benchs = [{
 	patterns: ['a/*', '!a/**']
 }, {
 	name: 'multiple positive globs',
-	patterns: ['a/*', 'b/*']
+	patterns: ['a/*', 'b/*', 'c/*']
 }];
 
 before(() => {
@@ -61,7 +81,10 @@ before(() => {
 	rimraf.sync(BENCH_DIR);
 	fs.mkdirSync(BENCH_DIR);
 	process.chdir(BENCH_DIR);
-	['a', 'b']
+
+	fs.writeFileSync('.gitignore', 'c');
+
+	['a', 'b', 'c']
 		.map(dir => `${dir}/`)
 		.forEach(dir => {
 			fs.mkdirSync(dir);

--- a/gitignore.js
+++ b/gitignore.js
@@ -1,8 +1,10 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const findUp = require('find-up');
 const glob = require('glob');
 const gitIgnore = require('ignore');
+const multimatch = require('multimatch');
 const pify = require('pify');
 const slash = require('slash');
 
@@ -68,20 +70,38 @@ const normalizeOpts = opts => {
 	return {ignore, cwd};
 };
 
+const PASS_THROUGH = () => false;
+
 module.exports = o => {
 	const opts = normalizeOpts(o);
+	const rootIgnore = path.join(opts.cwd, '.gitignore');
 
-	return globP('**/.gitignore', {ignore: opts.ignore, cwd: opts.cwd})
-		.then(paths => Promise.all(paths.map(file => getFile(file, opts.cwd))))
-		.then(files => reduceIgnore(files))
+	if (opts.ignore.length > 0 && multimatch(rootIgnore, opts.ignore)) {
+		return Promise.resolve(PASS_THROUGH);
+	}
+
+	if (!fs.existsSync(rootIgnore)) {
+		return Promise.resolve(PASS_THROUGH);
+	}
+
+	return getFile('.gitignore', opts.cwd)
+		.then(file => reduceIgnore([file]))
 		.then(ignores => getIsIgnoredPredecate(ignores, opts.cwd));
 };
 
 module.exports.sync = o => {
 	const opts = normalizeOpts(o);
+	const rootIgnore = path.join(opts.cwd, '.gitignore');
 
-	const paths = glob.sync('**/.gitignore', {ignore: opts.ignore, cwd: opts.cwd});
-	const files = paths.map(file => getFileSync(file, opts.cwd));
-	const ignores = reduceIgnore(files);
+	if (opts.ignore.length > 0 && multimatch(rootIgnore, opts.ignore)) {
+		return PASS_THROUGH;
+	}
+
+	if (!fs.existsSync(rootIgnore)) {
+		return PASS_THROUGH;
+	}
+
+	const file = getFileSync('.gitignore', opts.cwd);
+	const ignores = reduceIgnore([file]);
 	return getIsIgnoredPredecate(ignores, opts.cwd);
 };

--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
 	"dependencies": {
 		"array-union": "^1.0.1",
 		"dir-glob": "^2.0.0",
+		"find-up": "^2.1.0",
 		"glob": "^7.1.2",
 		"ignore": "^3.3.5",
+		"multimatch": "^2.1.0",
 		"pify": "^3.0.0",
 		"slash": "^1.0.0"
 	},


### PR DESCRIPTION
* See #50 
* sindresorhus/xo#234
* sindresorhus/xo#212

This changes the `.gitignore` handling to only scan for ignore files at `$CWD/.gitignore`, which results in better performance of `globby` runs. 

Previously globby scanned for `**/.gitignore`, which increased execution time in relation to the number of files in `cwd. 

This does **not** change the ignore filter to be applied before `glob` tasks are created.

## Considerations

* Should nested `.gitignore` files be supported?
* ~~Probably should move benchmarking for `.gitignore` handling here~~
* Should ignore files be searched from `${gitRoot}/` instead? (How to handle non-git dirs then?)

## Details

Tested via https://github.com/pixelass/ava-xo-test:

```
git clone https://github.com/pixelass/ava-xo-test.git
git clone https://github.com/sindresorhus/globby.git

cd globby 
git checkout perf-shallow-gitignore
npm install

cd ../ava-xo-test
npm install
# Prevent xo from finding the local (old) copy
mv node_modules/xo/cli.js node_modules/xo/_cli.js

# Local
# node --inspect --inspect-brk ./node_modules/xo/_cli.js 

# Development
# node --inspect --inspect-brk ../xo/cli.js 
```

### Before

```
~/Documents/oss/ava-xo-test master*
λ time ./node_modules/.bin/xo

  4 errors
       58.69 real        52.60 user         7.43 sys
```

<img width="1552" alt="globby-slow-gitignore" src="https://user-images.githubusercontent.com/4248851/35486180-ab7e58e8-046a-11e8-96e1-290cf2715d73.png">

The area with red borders signifies time spent in `getGitIgnoreFilter`

[CPU profile before](https://gist.githubusercontent.com/marionebl/c5503a6a007848de2bab3489059beaa4/raw/eee375cd63d049f488f0d3f7055a1de8d86b218e/globby-slow-gitignore.cpuprofile)

### After

```
~/Documents/oss/ava-xo-test master*
λ time node ../xo/cli.js

  5 errors
       42.90 real        39.16 user         5.81 sys
```

<img width="1552" alt="globby-simplified-gitignore" src="https://user-images.githubusercontent.com/4248851/35486395-aae3f228-046d-11e8-81ed-0d3a78818be3.png">

[CPU profile after](https://gist.githubusercontent.com/marionebl/c5503a6a007848de2bab3489059beaa4/raw/eee375cd63d049f488f0d3f7055a1de8d86b218e/globby-simplified-gitignore.cpuprofile)

