### PR TITLE
Remove `nodir` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,7 @@ const generateGlobTasks = (patterns, taskOpts) => {
 
 	taskOpts = Object.assign({
 		ignore: [],
-		expandDirectories: true,
-		onlyFiles: true
+		expandDirectories: true
 	}, taskOpts);
 
 	patterns.forEach((pattern, i) => {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const generateGlobTasks = (patterns, taskOpts) => {
 	taskOpts = Object.assign({
 		ignore: [],
 		expandDirectories: true,
-		nodir: true
+		onlyFiles: true
 	}, taskOpts);
 
 	patterns.forEach((pattern, i) => {


### PR DESCRIPTION
`fast-glob` doesn't use `nodir` but `onlyFiles`. I guess the tests pass because `onlyFiles` defaults to `true` in `fast-glob` anyway. We could even remove it.