### PR TITLE
docs: replace unsupported nodir option with onlyDirectories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ If set to `true`, `globby` will automatically glob directories for you. If you d
 })();
 ```
 
-Note that if you set this option to `false`, you won't get back matched directories unless you set `nodir: false`.
+Note that if you set this option to `false`, you won't get back matched directories unless you set [`onlyDirectories`](https://github.com/mrmlnc/fast-glob#onlydirectories) to `true`.
 
 ##### gitignore
 


### PR DESCRIPTION
fast-glob doesn't support glob's `nodir` option [1], but it supports an `onlyFiles` option which does the same thing, and an `onlyDirectories` option which does the inverse.

`onlyDirectories: true` is clearer in this case than `onlyFiles: false`, and `onlyDirectories` takes precedence over `onlyFiles` [2], so update the documentation to use that instead.

[1] https://github.com/mrmlnc/fast-glob#compatible-with-node-glob
[2] https://github.com/mrmlnc/fast-glob/pull/51