### PR TITLE
Fix link to fast-glob options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).
 
 Type: `Object`
 
-See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options) in addition to the ones below.
+See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones below.
 
 ##### expandDirectories
 


### PR DESCRIPTION
fast-glob must have changed their readme structure at some point as `#options` isn't a very helpful section, `#options-1` leads to the list of options and their uses