### PR TITLE
Fix `expandDirectories` and `ignores` option working together

### DIFF
--- a/test.js
+++ b/test.js
@@ -138,6 +138,15 @@ test('expandDirectories and ignores option', t => {
 	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
+test.failing('relative paths and ignores option', t => {
+	process.chdir(tmp);
+	t.deepEqual(m.sync('../tmp', {
+		cwd: process.cwd(),
+		ignore: ['tmp']
+	}), []);
+	process.chdir(cwd);
+});
+
 // Rejected for being an invalid pattern
 [
 	{},

--- a/test.js
+++ b/test.js
@@ -127,7 +127,7 @@ test.failing('expandDirectories:true and onlyFiles:false option', t => {
 	t.deepEqual(m.sync(tmp, {onlyFiles: false}), ['tmp', 'tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
-test.failing('expandDirectories and ignores option', t => {
+test('expandDirectories and ignores option', t => {
 	t.deepEqual(m.sync('tmp', {
 		ignore: ['tmp']
 	}), []);


### PR DESCRIPTION
I came across https://github.com/sindresorhus/globby/issues/62 when encountering an issue with relative paths + ignores. I tried fixing the relative path issue, but I've concluded that seems to be in `fast-glob`, but it did seem to fix #62, so I'm PR-ing it and a failing test case for the relative path

Fixes #62 