### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "globby",
-	"version": "8.0.1",
+	"version": "8.0.3",
 	"description": "Extends `glob` with support for multiple patterns and exposes a Promise API",
 	"license": "MIT",
 	"repository": "sindresorhus/globby",


### PR DESCRIPTION
dir-glob was updated recently so that when cwd is not a string, an error is thrown. This causes a downstream issue where postcss-cli now fails and throws an error. 

You made a code change to fix this but did not release the code change to npm but released 8.0.2, this PR is to bump the version number to 8.0.3 and nudge you to release it to npm 😄 