### PR TITLE
Add check to ensure `cwd` is a directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const assertPatternsInput = patterns => {
 
 const checkCwdOption = options => {
 	if (options && options.cwd && !fs.statSync(options.cwd).isDirectory()) {
-		throw new Error('Option `cwd` must be a path to a directory');
+		throw new Error('The `cwd` option must be a path to a directory');
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const arrayUnion = require('array-union');
 const glob = require('glob');
 const fastGlob = require('fast-glob');
@@ -15,9 +16,16 @@ const assertPatternsInput = patterns => {
 	}
 };
 
+const checkCwdOption = options => {
+	if (options && options.cwd && !fs.statSync(options.cwd).isDirectory()) {
+		throw new Error('Option `cwd` must be a path to a directory');
+	}
+};
+
 const generateGlobTasks = (patterns, taskOptions) => {
 	patterns = arrayUnion([].concat(patterns));
 	assertPatternsInput(patterns);
+	checkCwdOption(taskOptions);
 
 	const globTasks = [];
 

--- a/test.js
+++ b/test.js
@@ -243,20 +243,24 @@ test.failing('`{extension: false}` and `expandDirectories.extensions` option', t
 	);
 });
 
-// https://github.com/sindresorhus/globby/issues/105
-test.failing('throws ENOTDIR when specifying a file as cwd - async', async t => {
+test('throws when specifying a file as cwd - async', async t => {
 	const isFile = path.resolve('fixtures/gitignore/bar.js');
-	await t.throwsAsync(globby('.', {cwd: isFile}), {code: 'ENOTDIR'});
-	await t.throwsAsync(globby('*', {cwd: isFile}), {code: 'ENOTDIR'});
+	await t.throwsAsync(
+		globby('.', {cwd: isFile}),
+		'Option `cwd` must be a path to a directory'
+	);
+	await t.throwsAsync(
+		globby('*', {cwd: isFile}),
+		'Option `cwd` must be a path to a directory'
+	);
 });
 
-// https://github.com/sindresorhus/globby/issues/105
-test.failing('throws ENOTDIR when specifying a file as cwd - sync', t => {
+test('throws when specifying a file as cwd - sync', t => {
 	const isFile = path.resolve('fixtures/gitignore/bar.js');
 	t.throws(() => {
 		globby.sync('.', {cwd: isFile});
-	}, {code: 'ENOTDIR'});
+	}, 'Option `cwd` must be a path to a directory');
 	t.throws(() => {
 		globby.sync('*', {cwd: isFile});
-	}, {code: 'ENOTDIR'});
+	}, 'Option `cwd` must be a path to a directory');
 });

--- a/test.js
+++ b/test.js
@@ -245,22 +245,26 @@ test.failing('`{extension: false}` and `expandDirectories.extensions` option', t
 
 test('throws when specifying a file as cwd - async', async t => {
 	const isFile = path.resolve('fixtures/gitignore/bar.js');
+
 	await t.throwsAsync(
 		globby('.', {cwd: isFile}),
-		'Option `cwd` must be a path to a directory'
+		'The `cwd` option must be a path to a directory'
 	);
+
 	await t.throwsAsync(
 		globby('*', {cwd: isFile}),
-		'Option `cwd` must be a path to a directory'
+		'The `cwd` option must be a path to a directory'
 	);
 });
 
 test('throws when specifying a file as cwd - sync', t => {
 	const isFile = path.resolve('fixtures/gitignore/bar.js');
+
 	t.throws(() => {
 		globby.sync('.', {cwd: isFile});
-	}, 'Option `cwd` must be a path to a directory');
+	}, 'The `cwd` option must be a path to a directory');
+
 	t.throws(() => {
 		globby.sync('*', {cwd: isFile});
-	}, 'Option `cwd` must be a path to a directory');
+	}, 'The `cwd` option must be a path to a directory');
 });


### PR DESCRIPTION
I thought about just throwing `ENOTDIR`, but I think a descriptive error is more helpful in this situation.

Fixes #105