### PR TITLE
Add `globby.stream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,16 @@ declare const globby: {
 	): string[];
 
 	/**
+	@param patterns - See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
+	@returns The stream of matching paths.
+	*/
+	stream(
+		patterns: string | readonly string[],
+		options?: globby.GlobbyOptions
+	): NodeJS.ReadableStream;
+
+	/**
 	Note that you should avoid running the same tasks multiple times as they contain a file system cache. Instead, run this method each time to ensure file system changes are taken into consideration.
 
 	@param patterns - See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,10 +118,10 @@ declare const globby: {
 
 	@example
 	```
-	import {stream} from 'globby';
+	import globby = require('globby');
 
 	(async () => {
-		for await (const path of stream('*.tmp')) {
+		for await (const path of globby.stream('*.tmp')) {
 			console.log(path);
 		}
 	})();

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,17 @@ declare const globby: {
 	@param patterns - See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).
 	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
 	@returns The stream of matching paths.
+
+	@example
+	```
+	import {stream} from 'globby';
+
+	(async () => {
+		for await (const path of stream('*.tmp')) {
+			console.log(path);
+		}
+	})();
+	```
 	*/
 	stream(
 		patterns: string | readonly string[],

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,7 @@ import {
 	GlobTask,
 	FilterFunction,
 	sync as globbySync,
+	stream as globbyStream,
 	generateGlobTasks,
 	hasMagic,
 	gitignore
@@ -44,6 +45,33 @@ expectType<string[]>(
 );
 expectType<string[]>(globbySync('*.tmp', {gitignore: true}));
 expectType<string[]>(globbySync('*.tmp', {ignore: ['**/b.tmp']}));
+
+// Globby (stream)
+expectType<NodeJS.ReadableStream>(globbyStream('*.tmp'));
+expectType<NodeJS.ReadableStream>(globbyStream(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+
+expectType<NodeJS.ReadableStream>(globbyStream('*.tmp', {expandDirectories: false}));
+expectType<NodeJS.ReadableStream>(globbyStream('*.tmp', {expandDirectories: ['a*', 'b*']}));
+expectType<NodeJS.ReadableStream>(
+	globbyStream('*.tmp', {
+		expandDirectories: {
+			files: ['a', 'b'],
+			extensions: ['tmp']
+		}
+	})
+);
+expectType<NodeJS.ReadableStream>(globbyStream('*.tmp', {gitignore: true}));
+expectType<NodeJS.ReadableStream>(globbyStream('*.tmp', {ignore: ['**/b.tmp']}));
+
+(async () => {
+	const streamResult = [];
+	for await (const path of globbyStream('*.tmp')) {
+		streamResult.push(path);
+	}
+	// `NodeJS.ReadableStream` is not generic, unfortunately,
+	// so it seems `(string | Buffer)[]` is the best we can get here
+	expectType<(string | Buffer)[]>(streamResult);
+})();
 
 // GenerateGlobTasks
 expectType<GlobTask[]>(generateGlobTasks('*.tmp'));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	"files": [
 		"index.js",
 		"gitignore.js",
-		"index.d.ts"
+		"index.d.ts",
+		"stream-utils.js"
 	],
 	"keywords": [
 		"all",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
 		"fast-glob": "^2.2.6",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",
+		"merge2": "^1.2.3",
 		"slash": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",
+		"get-stream": "^5.1.0",
 		"glob-stream": "^6.1.0",
 		"globby": "sindresorhus/globby#master",
 		"matcha": "^0.7.0",

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Returns `string[]` of matching paths.
 
 ### globby.stream(patterns, options?)
 
-Returns a `ReadableStream` of matching paths.
+Returns a [`stream.Readable`](https://nodejs.org/api/stream.html#stream_readable_streams) of matching paths.
 
 ### globby.generateGlobTasks(patterns, options?)
 

--- a/readme.md
+++ b/readme.md
@@ -97,11 +97,11 @@ Returns `string[]` of matching paths.
 
 Returns a [`stream.Readable`](https://nodejs.org/api/stream.html#stream_readable_streams) of matching paths.
 
-Since Node v10 [readable streams are iterable](https://nodejs.org/api/stream.html#stream_readable_symbol_asynciterator), so you can loop over glob matches in a [`for await...of` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) like this:
+Since Node.js 10, [readable streams are iterable](https://nodejs.org/api/stream.html#stream_readable_symbol_asynciterator), so you can loop over glob matches in a [`for await...of` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) like this:
 
 ```js
 for await (const path of globby.stream('*.tmp')) {
-	console.log({ path });
+	console.log(path);
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ Respect ignore patterns in `.gitignore` files that apply to the globbed files.
 
 Returns `string[]` of matching paths.
 
+### globby.stream(patterns, options?)
+
+Returns a `ReadableStream` of matching paths.
+
 ### globby.generateGlobTasks(patterns, options?)
 
 Returns an `object[]` in the format `{pattern: string, options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,8 @@ Default: `true`
 If set to `true`, `globby` will automatically glob directories for you. If you define an `Array` it will only glob files that matches the patterns inside the `Array`. You can also define an `object` with `files` and `extensions` like below:
 
 ```js
+const globby = require('globby');
+
 (async () => {
 	const paths = await globby('images', {
 		expandDirectories: {
@@ -100,9 +102,13 @@ Returns a [`stream.Readable`](https://nodejs.org/api/stream.html#stream_readable
 Since Node.js 10, [readable streams are iterable](https://nodejs.org/api/stream.html#stream_readable_symbol_asynciterator), so you can loop over glob matches in a [`for await...of` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) like this:
 
 ```js
-for await (const path of globby.stream('*.tmp')) {
-	console.log(path);
-}
+const globby = require('globby');
+
+(async () => {
+	for await (const path of globby.stream('*.tmp')) {
+		console.log(path);
+	}
+})();
 ```
 
 ### globby.generateGlobTasks(patterns, options?)

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,14 @@ Returns `string[]` of matching paths.
 
 Returns a [`stream.Readable`](https://nodejs.org/api/stream.html#stream_readable_streams) of matching paths.
 
+Since Node v10 [readable streams are iterable](https://nodejs.org/api/stream.html#stream_readable_symbol_asynciterator), so you can loop over glob matches in a [`for await...of` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) like this:
+
+```js
+for await (const path of globby.stream('*.tmp')) {
+	console.log({ path });
+}
+```
+
 ### globby.generateGlobTasks(patterns, options?)
 
 Returns an `object[]` in the format `{pattern: string, options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.

--- a/stream-utils.js
+++ b/stream-utils.js
@@ -1,0 +1,46 @@
+'use strict';
+const {Transform} = require('stream');
+
+class ObjectTransform extends Transform {
+	constructor() {
+		super({
+			objectMode: true
+		});
+	}
+}
+
+class FilterStream extends ObjectTransform {
+	constructor(filter) {
+		super();
+		this._filter = filter;
+	}
+
+	_transform(data, encoding, callback) {
+		if (this._filter(data)) {
+			this.push(data);
+		}
+
+		callback();
+	}
+}
+
+class UniqueStream extends ObjectTransform {
+	constructor() {
+		super();
+		this._pushed = new Set();
+	}
+
+	_transform(data, encoding, callback) {
+		if (!this._pushed.has(data)) {
+			this.push(data);
+			this._pushed.add(data);
+		}
+
+		callback();
+	}
+}
+
+module.exports = {
+	FilterStream,
+	UniqueStream
+};

--- a/test.js
+++ b/test.js
@@ -264,7 +264,7 @@ test('gitignore option defaults to false - sync', t => {
 
 test('gitignore option defaults to false - stream', async t => {
 	const actual = await getStream.array(globby.stream('*', {onlyFiles: false}));
-	t.true(actual.indexOf('node_modules') > -1);
+	t.true(actual.includes('node_modules'));
 });
 
 test('respects gitignore option true - async', async t => {
@@ -279,7 +279,7 @@ test('respects gitignore option true - sync', t => {
 
 test('respects gitignore option true - stream', async t => {
 	const actual = await getStream.array(globby.stream('*', {gitignore: true, onlyFiles: false}));
-	t.false(actual.indexOf('node_modules') > -1);
+	t.false(actual.includes('node_modules'));
 });
 
 test('respects gitignore option false - async', async t => {
@@ -300,7 +300,7 @@ test('gitignore option with stats option', async t => {
 
 test('respects gitignore option false - stream', async t => {
 	const actual = await getStream.array(globby.stream('*', {gitignore: false, onlyFiles: false}));
-	t.true(actual.indexOf('node_modules') > -1);
+	t.true(actual.includes('node_modules'));
 });
 
 // https://github.com/sindresorhus/globby/issues/97

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ test('glob - stream', async t => {
 	t.deepEqual((await getStream.array(globby.stream('*.tmp'))).sort(), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
 });
 
-// Readable streams are iterable since node version 10, but this test runs on 6 and 8 too.
+// Readable streams are iterable since Node.js 10, but this test runs on 6 and 8 too.
 // So we define the test only if async iteration is supported.
 if (Symbol.asyncIterator) {
 	// For the reason behind `eslint-disable` below see https://github.com/avajs/eslint-plugin-ava/issues/216

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ test('glob - stream', async t => {
 	t.deepEqual((await getStream.array(globby.stream('*.tmp'))).sort(), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
 });
 
-// Readable streams are readable since node version 10, but this test runs on 6 and 8 too.
+// Readable streams are iterable since node version 10, but this test runs on 6 and 8 too.
 // So we define the test only if async iteration is supported.
 if (Symbol.asyncIterator) {
 	// For the reason behind `eslint-disable` below see https://github.com/avajs/eslint-plugin-ava/issues/216


### PR DESCRIPTION
Fixes #83

This adds support for async iteration by adding `globby.stream` which returns a `ReadableStream`. 

Node 10 introduced experimental [async iterator support to `ReadableStream`](https://nodejs.org/api/stream.html#stream_readable_symbol_asynciterator) so if supported by one's node version, one can use `globby.stream` in a `for-await-of` loop as witnessed by this test https://github.com/futpib/globby/blob/958e81505b1baa7d73e29dbe3468123032cce9cf/test.js#L85-L92