### PR TITLE
Fix using the `gitignore` and `stats` options together

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ const checkCwdOption = options => {
 	}
 };
 
+const getPathString = p => p instanceof fs.Stats ? p.path : p;
+
 const generateGlobTasks = (patterns, taskOptions) => {
 	patterns = arrayUnion([].concat(patterns));
 	assertPatternsInput(patterns);
@@ -110,7 +112,7 @@ const globby = (patterns, options) => {
 			return getTasks
 				.then(tasks => Promise.all(tasks.map(task => fastGlob(task.pattern, task.options))))
 				.then(paths => arrayUnion(...paths))
-				.then(paths => paths.filter(p => !filter(p)));
+				.then(paths => paths.filter(p => !filter(getPathString(p))));
 		});
 };
 

--- a/test.js
+++ b/test.js
@@ -221,6 +221,12 @@ test('respects gitignore option false - sync', t => {
 	t.true(actual.indexOf('node_modules') > -1);
 });
 
+test('gitignore option with stats option', async t => {
+	const res = await globby('*', {gitignore: true, stats: true});
+	const actual = res.map(s => s.path);
+	t.false(actual.indexOf('node_modules') > -1);
+});
+
 // https://github.com/sindresorhus/globby/issues/97
 test.failing('`{extension: false}` and `expandDirectories.extensions` option', t => {
 	t.deepEqual(


### PR DESCRIPTION
Currently you can't use `{ gitignore: true }` and `{ stats: true }` together because there's a bunch of code that expects paths to be strings.

This coerces `fs.Stats` objects to strings for that code.
