### PR TITLE
Upgrade `fast-glob` package to v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const checkCwdOption = options => {
 	}
 };
 
-const getPathString = p => p instanceof fs.Stats ? p.path : p;
+const getPathString = p => p.stats instanceof fs.Stats ? p.path : p;
 
 const generateGlobTasks = (patterns, taskOptions) => {
 	patterns = arrayUnion([].concat(patterns));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const fs = require('fs');
-const path = require('path');
 const arrayUnion = require('array-union');
 const merge2 = require('merge2');
 const glob = require('glob');
@@ -90,16 +89,14 @@ const getFilterSync = options => {
 		DEFAULT_FILTER;
 };
 
-const normalizeGlob = glob => glob.split(path.sep).join(path.posix.sep);
-
 const globToTask = task => glob => {
 	const {options} = task;
 	if (options.ignore && Array.isArray(options.ignore) && options.expandDirectories) {
-		options.ignore = dirGlob.sync(options.ignore).map(normalizeGlob);
+		options.ignore = dirGlob.sync(options.ignore);
 	}
 
 	return {
-		pattern: normalizeGlob(glob),
+		pattern: glob,
 		options
 	};
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
 const arrayUnion = require('array-union');
 const merge2 = require('merge2');
 const glob = require('glob');
@@ -89,14 +90,16 @@ const getFilterSync = options => {
 		DEFAULT_FILTER;
 };
 
+const normalizeGlob = glob => glob.split(path.sep).join(path.posix.sep);
+
 const globToTask = task => glob => {
 	const {options} = task;
 	if (options.ignore && Array.isArray(options.ignore) && options.expandDirectories) {
-		options.ignore = dirGlob.sync(options.ignore);
+		options.ignore = dirGlob.sync(options.ignore).map(normalizeGlob);
 	}
 
 	return {
-		pattern: glob,
+		pattern: normalizeGlob(glob),
 		options
 	};
 };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	"dependencies": {
 		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
-		"dir-glob": "^2.2.2",
+		"dir-glob": "^3.0.0",
 		"fast-glob": "^3.0.2",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	"dependencies": {
 		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
-		"dir-glob": "^3.0.0",
+		"dir-glob": "yhatt/dir-glob#revert-excessive-posix-join",
 		"fast-glob": "^3.0.2",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
 		"dir-glob": "^2.2.2",
-		"fast-glob": "^2.2.6",
+		"fast-glob": "^3.0.2",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",
 		"merge2": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
 	"dependencies": {
 		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
-		"dir-glob": "yhatt/dir-glob#revert-excessive-posix-join",
-		"fast-glob": "^3.0.2",
+		"dir-glob": "^3.0.1",
+		"fast-glob": "^3.0.3",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",
 		"merge2": "^1.2.3",

--- a/test.js
+++ b/test.js
@@ -185,7 +185,7 @@ test('expandDirectories and ignores option', t => {
 	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
-test('relative paths and ignores option', t => {
+test.failing('relative paths and ignores option', t => {
 	process.chdir(tmp);
 	t.deepEqual(globby.sync('../tmp', {
 		cwd: process.cwd(),

--- a/test.js
+++ b/test.js
@@ -185,7 +185,7 @@ test('expandDirectories and ignores option', t => {
 	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
-test.failing('relative paths and ignores option', t => {
+test('relative paths and ignores option', t => {
 	process.chdir(tmp);
 	t.deepEqual(globby.sync('../tmp', {
 		cwd: process.cwd(),


### PR DESCRIPTION
[fast-glob v3](https://github.com/mrmlnc/fast-glob/releases/tag/3.0.0) has an improved performance and some bug fixes from [micromatch](https://github.com/micromatch/micromatch) upstream package.

In Node 10.16.0 on my Mac, `npm run bench` would be faster 3 to 4 times than `master`.

```bash
$ npm run bench

> globby@9.2.0 bench /Users/yhatt/Programs/globby
> npm update glob-stream fast-glob && matcha bench.js

+ fast-glob@3.0.2
added 6 packages from 5 contributors, removed 3 packages and updated 7 packages in 4.19s
(node:13488) [DEP0006] DeprecationWarning: child_process: options.customFds option is deprecated. Use options.stdio instead.

                      negative globs (some files inside dir)
             682 op/s » globby async (working directory)
             216 op/s » globby async (upstream/master)
             992 op/s » globby sync (working directory)
             285 op/s » globby sync (upstream/master)
             250 op/s » glob-stream
           1,013 op/s » fast-glob async
           1,182 op/s » fast-glob sync

                      negative globs (whole dir)
             904 op/s » globby async (working directory)
             252 op/s » globby async (upstream/master)
           1,061 op/s » globby sync (working directory)
             294 op/s » globby sync (upstream/master)
           5,097 op/s » glob-stream
           1,024 op/s » fast-glob async
           1,254 op/s » fast-glob sync

                      multiple positive globs
             498 op/s » globby async (working directory)
             120 op/s » globby async (upstream/master)
             489 op/s » globby sync (working directory)
             143 op/s » globby sync (upstream/master)
             160 op/s » glob-stream
             589 op/s » fast-glob async
             580 op/s » fast-glob sync


  Suites:  3
  Benches: 21
  Elapsed: 16,987.17 ms

```

I was received a report to my tool, about a wrong globbing by globby (marp-team/marp-cli#108). It's a bug from the upstream package so would be resolved by this.

