### PR TITLE
Get rid of `glob` dependency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ declare const globby: {
 	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
 	@returns The matching paths.
 
 	@example
@@ -110,7 +110,7 @@ declare const globby: {
 	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
 	@returns The matching paths.
 	*/
 	sync(
@@ -124,7 +124,7 @@ declare const globby: {
 	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
 	@returns The stream of matching paths.
 
 	@example
@@ -147,7 +147,7 @@ declare const globby: {
 	Note that you should avoid running the same tasks multiple times as they contain a file system cache. Instead, run this method each time to ensure file system changes are taken into consideration.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones in this package.
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
 	@returns An object in the format `{pattern: string, options: object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
 	*/
 	generateGlobTasks(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import {IOptions as NodeGlobOptions} from 'glob';
 import {Options as FastGlobOptions} from 'fast-glob';
 
 declare namespace globby {
@@ -157,17 +156,17 @@ declare const globby: {
 	): globby.GlobTask[];
 
 	/**
-	Note that the options affect the results. If `noext: true` is set, then `+(a|b)` will not be considered a magic pattern. If the pattern has a brace expansion, like `a/{b/c,x/y}`, then that is considered magical, unless `nobrace: true` is set.
+	Note that the options affect the results.
 
-	This function is backed by [`node-glob`](https://github.com/isaacs/node-glob#globhasmagicpattern-options).
+	This function is backed by [`fast-glob`](https://github.com/mrmlnc/fast-glob#isdynamicpatternpattern-options).
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	@param options - See the [`node-glob` options](https://github.com/isaacs/node-glob#globhasmagicpattern-options).
+	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3).
 	@returns Whether there are any special glob characters in the `patterns`.
 	*/
 	hasMagic(
 		patterns: string | readonly string[],
-		options?: NodeGlobOptions
+		options?: FastGlobOptions
 	): boolean;
 
 	readonly gitignore: Gitignore;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 const fs = require('fs');
 const arrayUnion = require('array-union');
 const merge2 = require('merge2');
-const glob = require('glob');
 const fastGlob = require('fast-glob');
 const dirGlob = require('dir-glob');
 const gitignore = require('./gitignore');
@@ -173,6 +172,6 @@ module.exports.generateGlobTasks = generateGlobTasks;
 
 module.exports.hasMagic = (patterns, options) => []
 	.concat(patterns)
-	.some(pattern => glob.hasMagic(pattern, options));
+	.some(pattern => fastGlob.isDynamicPattern(pattern, options));
 
 module.exports.gitignore = gitignore;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -95,7 +95,7 @@ expectType<GlobTask[]>(generateGlobTasks('*.tmp', {ignore: ['**/b.tmp']}));
 // HasMagic
 expectType<boolean>(hasMagic('**'));
 expectType<boolean>(hasMagic(['**', 'path1', 'path2']));
-expectType<boolean>(hasMagic(['**', 'path1', 'path2'], {noext: true}));
+expectType<boolean>(hasMagic(['**', 'path1', 'path2'], {extglob: false}));
 
 // Gitignore
 expectType<Promise<FilterFunction>>(gitignore());

--- a/package.json
+++ b/package.json
@@ -56,11 +56,9 @@
 		"git"
 	],
 	"dependencies": {
-		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
 		"dir-glob": "^3.0.1",
 		"fast-glob": "^3.1.0",
-		"glob": "^7.1.3",
 		"ignore": "^5.1.1",
 		"merge2": "^1.2.3",
 		"slash": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@types/glob": "^7.1.1",
 		"array-union": "^2.1.0",
 		"dir-glob": "^3.0.1",
-		"fast-glob": "^3.0.3",
+		"fast-glob": "^3.1.0",
 		"glob": "^7.1.3",
 		"ignore": "^5.1.1",
 		"merge2": "^1.2.3",

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ See supported `minimatch` [patterns](https://github.com/isaacs/minimatch#usage).
 
 Type: `object`
 
-See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-1) in addition to the ones below.
+See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones below.
 
 ##### expandDirectories
 

--- a/readme.md
+++ b/readme.md
@@ -123,9 +123,9 @@ Note that you should avoid running the same tasks multiple times as they contain
 
 Returns a `boolean` of whether there are any special glob characters in the `patterns`.
 
-Note that the options affect the results. If `noext: true` is set, then `+(a|b)` will not be considered a magic pattern. If the pattern has a brace expansion, like `a/{b/c,x/y}`, then that is considered magical, unless `nobrace: true` is set.
+Note that the options affect the results.
 
-This function is backed by [`node-glob`](https://github.com/isaacs/node-glob#globhasmagicpattern-options)
+This function is backed by [`fast-glob`](https://github.com/mrmlnc/fast-glob#isdynamicpatternpattern-options).
 
 ### globby.gitignore(options?)
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #109

### What changes did you make? (Give an overview)

* Replace `glob.hasMagic` by `fg.isDynamicPattern`;
* Update documentation in the `README.md` and `.d.ts` files;
* Drop `glob` and `@types/glob` dependencies;