### PR TITLE
Fix using `gitignore` and `absolute` options at the same time on Windows

### DIFF
--- a/gitignore.js
+++ b/gitignore.js
@@ -83,7 +83,7 @@ const getFileSync = (file, cwd) => {
 
 const normalizeOptions = ({
 	ignore = [],
-	cwd = process.cwd()
+	cwd = slash(process.cwd())
 } = {}) => {
 	return {ignore, cwd};
 };

--- a/test.js
+++ b/test.js
@@ -298,6 +298,11 @@ test('gitignore option with stats option', async t => {
 	t.false(actual.includes('node_modules'));
 });
 
+test('gitignore option with absolute option', async t => {
+	const result = await globby('*', {gitignore: true, absolute: true});
+	t.false(result.includes('node_modules'));
+});
+
 test('respects gitignore option false - stream', async t => {
 	const actual = await getStream.array(globby.stream('*', {gitignore: false, onlyFiles: false}));
 	t.true(actual.includes('node_modules'));


### PR DESCRIPTION
When `globby` is invoked with `globby('*', { absolute: true, gitignore: true })` on Windows systems, the assertion added in 4af038edf82f6be9fe71f003e5db53dae879e687 **always** triggers. This is because when we default the `cwd` in `normalizeOptions`, we didn't convert from `C:\\` style paths to forward slashes.

A simple work around for users hitting this issue, is to provide a `cwd` option that has already been converted:

```js
globby('*', { absolute: true, gitignore: true, cwd: slash(process.cwd()) })
```
---

The test added here was failing on Windows, example output prior to the fixes:

```
  test » gitignore option with absolute option
  C:\Users\travis\build\rwjblue\globby\gitignore.js:52
   51:
   52:     throw new Error(`Path ${p} is not in cwd ${cwd}`);
   53:   }
  Rejected promise returned by test. Reason:
  Error {
    message: 'Path C:/Users/travis/build/rwjblue/globby/a.tmp is not in cwd C:\\Users\\travis\\build\\rwjblue\\globby',
  }
```

Related to #133 (though it isn't clear that this fixes **all** of the scenarios that #133 is exploring).