### PR TITLE
Fix TypeScript type for the `expandDirectories` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,8 @@ import {Options as FastGlobOptions} from 'fast-glob';
 declare namespace globby {
 	type ExpandDirectoriesOption =
 		| boolean
-		| ReadonlyArray<string>
-		| {files: readonly string[]; extensions: readonly string[]};
+		| readonly string[]
+		| {files?: readonly string[]; extensions?: readonly string[]};
 
 	interface GlobbyOptions extends FastGlobOptions {
 		/**


### PR DESCRIPTION
`expandDirectories` is passed to dir-glob.
dir-glob doesn't require `files` or `extensions` options.
https://github.com/kevva/dir-glob/blob/dc6e7978a641fd1e8e4329ba474fb0af65b52519/index.js#L20-L42