### PR TITLE
Normalize file paths to posix for gitignore calculation

### DIFF
--- a/gitignore.js
+++ b/gitignore.js
@@ -44,6 +44,7 @@ const reduceIgnore = files => {
 };
 
 const ensureAbsolutePathForCwd = (cwd, p) => {
+	cwd = slash(cwd);
 	if (path.isAbsolute(p)) {
 		if (p.startsWith(cwd)) {
 			return p;

--- a/gitignore.test.js
+++ b/gitignore.test.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import test from 'ava';
+import slash from 'slash';
 import gitignore from './gitignore';
 
 test('gitignore', async t => {
@@ -8,6 +9,12 @@ test('gitignore', async t => {
 	const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
 	const expected = ['bar.js'];
 	t.deepEqual(actual, expected);
+});
+
+test('gitignore - mixed path styles', async t => {
+	const cwd = path.join(__dirname, 'fixtures/gitignore');
+	const isIgnored = await gitignore({cwd});
+	t.true(isIgnored(slash(path.resolve(cwd, 'foo.js'))));
 });
 
 test('gitignore - sync', t => {


### PR DESCRIPTION
This at least solves the problem in #133 when using Windows that I mentioned. The test I added works on Windows to verify the fix but has no effect on Linux because the filepaths are already normalized.

I don't think it fixes everything in #133, as it's really hard to test all those scenarios with the limited public interface.