### PR TITLE
Fix broken catch statement causing crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch(err) {
+	} catch(error) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch(error) {
+	} catch (error) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch (error) {
+	} catch (_) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch {
+	} catch(err) {
 		return;
 	}
 


### PR DESCRIPTION
```
node_modules/globby/index.js:28
	} catch {
	        ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (node_modules/postcss-mixins/index.js:6:14)
```
