### PR TITLE
fix: try...catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch {
+	} catch (err) {
 		return;
 	}
 


### PR DESCRIPTION
When building in the nuxt environment, an error occurs in that part.
The error was resolved by correcting the catch clause.

```
(node:35566) UnhandledPromiseRejectionWarning: /Users/jihonglee/develop/co-work/modern-apim-bff/node_modules/globby/index.js:28
        } catch {

        } catch {
                ^

SyntaxError: Unexpected token {
    at Object.Module._extensions..js (module.js:664:10)
    at Object.Module._extensions..js (module.js:664:10)
```

build env:
```
"nodemon": "^1.18.9",
"nuxt": "^2.14.12",
"vue": "^2.6.12",
```