### PR TITLE
Add `ignoreFiles` option

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -2,7 +2,7 @@ import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
 import fastGlob from 'fast-glob';
-import gitIgnore from 'ignore';
+import ignore from 'ignore';
 import slash from 'slash';
 import {toPath} from './utilities.js';
 
@@ -35,7 +35,7 @@ const parseGitIgnore = (content, options) => {
 };
 
 const reduceIgnore = files => {
-	const ignores = gitIgnore();
+	const ignores = ignore();
 	for (const file of files) {
 		ignores.add(parseGitIgnore(file.content, {
 			cwd: file.cwd,

--- a/ignore.js
+++ b/ignore.js
@@ -77,10 +77,10 @@ const normalizeOptions = (options = {}) => ({
 	cwd: toPath(options.cwd) || slash(process.cwd()),
 });
 
-export const isGitIgnored = async options => {
+export const isIgnored = async (pattern, options) => {
 	const {cwd} = normalizeOptions(options);
 
-	const paths = await fastGlob('**/.gitignore', {cwd, ...gitignoreGlobOptions});
+	const paths = await fastGlob(pattern, {cwd, ...gitignoreGlobOptions});
 
 	const files = await Promise.all(paths.map(file => getFile(file, cwd)));
 	const ignores = reduceIgnore(files);
@@ -88,10 +88,10 @@ export const isGitIgnored = async options => {
 	return getIsIgnoredPredicate(ignores, cwd);
 };
 
-export const isGitIgnoredSync = options => {
+export const isIgnoredSync = (pattern, options) => {
 	const {cwd} = normalizeOptions(options);
 
-	const paths = fastGlob.sync('**/.gitignore', {cwd, ...gitignoreGlobOptions});
+	const paths = fastGlob.sync(pattern, {cwd, ...gitignoreGlobOptions});
 
 	const files = paths.map(file => getFileSync(file, cwd));
 	const ignores = reduceIgnore(files);

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,10 +42,19 @@ export interface Options extends FastGlobOptionsWithoutCwd {
 
 	/**
 	Respect ignore patterns in `.gitignore` files that apply to the globbed files.
+	This option takes precedence over the `ignoreFiles` option.
 
 	@default false
 	*/
 	readonly gitignore?: boolean;
+
+	/**
+	A glob pattern to look for ignore files, which are then used to ignore globbed files. This is a more generic form of the `gitignore` option, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
+	This value is unused if `{ gitignore: true }`, since `gitignore` takes precedence.
+
+	@default undefined
+	*/
+	readonly ignoreFiles?: string;
 
 	/**
 	The current working directory in which to search.

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export interface Options extends FastGlobOptionsWithoutCwd {
 
 	/**
 	Respect ignore patterns in `.gitignore` files that apply to the globbed files.
-	This option takes precedence over the `ignoreFiles` option.
+	This option merges with `ignoreFiles` is both are specified.
 
 	@default false
 	*/
@@ -50,11 +50,11 @@ export interface Options extends FastGlobOptionsWithoutCwd {
 
 	/**
 	A glob pattern to look for ignore files, which are then used to ignore globbed files. This is a more generic form of the `gitignore` option, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
-	This value is unused if `{ gitignore: true }`, since `gitignore` takes precedence.
+	This option merges with `.gitignore` if both are specified.
 
 	@default undefined
 	*/
-	readonly ignoreFiles?: string;
+	readonly ignoreFiles?: string | string[];
 
 	/**
 	The current working directory in which to search.

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const assertPatternsInput = patterns => {
 };
 
 const toPatternsArray = patterns => {
-	patterns = [...new Set([patterns].flat(Infinity))];
+	patterns = [...new Set([patterns].flat())];
 	assertPatternsInput(patterns);
 	return patterns;
 };
@@ -57,10 +57,11 @@ const getIgnoreFilesPatterns = options => {
 		return [];
 	}
 
-	const patterns = [
-		options.gitignore && '**/.gitignore',
-		options.ignoreFiles,
-	].filter(Boolean);
+	const patterns = toPatternsArray(options.ignoreFiles || []);
+	if (options.gitignore) {
+		patterns.push('**/.gitignore');
+	}
+
 	return toPatternsArray(patterns);
 };
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ const getIgnoreFilesPatterns = options => {
 		patterns.push('**/.gitignore');
 	}
 
-	return toPatternsArray(patterns);
+	return patterns;
 };
 
 const getFilter = async options => {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"files": [
 		"index.js",
 		"index.d.ts",
-		"gitignore.js",
+		"ignore.js",
 		"utilities.js"
 	],
 	"keywords": [

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Based on [`fast-glob`](https://github.com/mrmlnc/fast-glob) but adds a bunch of 
 - Multiple patterns
 - Negated patterns: `['foo*', '!foobar']`
 - Expands directories: `foo` → `foo/**/*`
-- Supports `.gitignore`
+- Supports `.gitignore`, or any similar ignore file configuration.
 - Supports `URL` as `cwd`
 
 ## Install
@@ -87,6 +87,17 @@ Type: `boolean`\
 Default: `false`
 
 Respect ignore patterns in `.gitignore` files that apply to the globbed files.
+
+This option takes precedence over the `ignoreFiles` option.
+
+##### ignoreFiles
+
+Type: `string`\
+Default: `undefined`
+
+A glob pattern to look for ignore files, which are then used to ignore globbed files. This is a more generic form of the `gitignore` option, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
+
+This value is unused if `{ gitignore: true }`, because `gitignore` takes precedence.
 
 ### globbySync(patterns, options?)
 

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -237,6 +237,16 @@ test('gitignore option and objectMode option', async t => {
 	t.truthy(result[0].path);
 });
 
+test('respects ignoreFiles string option', async t => {
+	const actual = await runGlobby(t, '*', {gitignore: false, ignoreFiles: '.gitignore', onlyFiles: false});
+	t.false(actual.includes('node_modules'));
+});
+
+test('respects ignoreFiles array option', async t => {
+	const actual = await runGlobby(t, '*', {gitignore: false, ignoreFiles: ['.gitignore'], onlyFiles: false});
+	t.false(actual.includes('node_modules'));
+});
+
 test('`{extension: false}` and `expandDirectories.extensions` option', async t => {
 	for (const temporaryDirectory of getPathValues(temporary)) {
 		t.deepEqual(

--- a/tests/ignore.js
+++ b/tests/ignore.js
@@ -1,63 +1,65 @@
 import path from 'node:path';
 import test from 'ava';
 import slash from 'slash';
-import {isGitIgnored, isGitIgnoredSync} from '../gitignore.js';
+import {isIgnored, isIgnoredSync} from '../ignore.js';
 import {
 	PROJECT_ROOT,
 	getPathValues,
 } from './utilities.js';
 
-test('gitignore', async t => {
+const gitignorePattern = '**/.gitignore';
+
+test('ignore', async t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
 		// eslint-disable-next-line no-await-in-loop
-		const isIgnored = await isGitIgnored({cwd});
-		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+		const ignored = await isIgnored(gitignorePattern, {cwd});
+		const actual = ['foo.js', 'bar.js'].filter(file => !ignored(file));
 		const expected = ['bar.js'];
 		t.deepEqual(actual, expected);
 	}
 });
 
-test('gitignore - mixed path styles', async t => {
+test('ignore - mixed path styles', async t => {
 	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	for (const cwd of getPathValues(directory)) {
 		// eslint-disable-next-line no-await-in-loop
-		const isIgnored = await isGitIgnored({cwd});
-		t.true(isIgnored(slash(path.resolve(directory, 'foo.js'))));
+		const ignored = await isIgnored(gitignorePattern, {cwd});
+		t.true(ignored(slash(path.resolve(directory, 'foo.js'))));
 	}
 });
 
-test('gitignore - os paths', async t => {
+test('ignore - os paths', async t => {
 	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	for (const cwd of getPathValues(directory)) {
 		// eslint-disable-next-line no-await-in-loop
-		const isIgnored = await isGitIgnored({cwd});
-		t.true(isIgnored(path.resolve(directory, 'foo.js')));
+		const ignored = await isIgnored(gitignorePattern, {cwd});
+		t.true(ignored(path.resolve(directory, 'foo.js')));
 	}
 });
 
-test('gitignore - sync', t => {
+test('ignore - sync', t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
-		const isIgnored = isGitIgnoredSync({cwd});
-		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+		const ignored = isIgnoredSync(gitignorePattern, {cwd});
+		const actual = ['foo.js', 'bar.js'].filter(file => !ignored(file));
 		const expected = ['bar.js'];
 		t.deepEqual(actual, expected);
 	}
 });
 
-test('negative gitignore', async t => {
+test('negative ignore', async t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/negative'))) {
 		// eslint-disable-next-line no-await-in-loop
-		const isIgnored = await isGitIgnored({cwd});
-		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+		const ignored = await isIgnored(gitignorePattern, {cwd});
+		const actual = ['foo.js', 'bar.js'].filter(file => !ignored(file));
 		const expected = ['foo.js'];
 		t.deepEqual(actual, expected);
 	}
 });
 
-test('negative gitignore - sync', t => {
+test('negative ignore - sync', t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/negative'))) {
-		const isIgnored = isGitIgnoredSync({cwd});
-		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
+		const ignored = isIgnoredSync(gitignorePattern, {cwd});
+		const actual = ['foo.js', 'bar.js'].filter(file => !ignored(file));
 		const expected = ['foo.js'];
 		t.deepEqual(actual, expected);
 	}
@@ -66,14 +68,14 @@ test('negative gitignore - sync', t => {
 test('multiple negation', async t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/multiple-negation'))) {
 		// eslint-disable-next-line no-await-in-loop
-		const isIgnored = await isGitIgnored({cwd});
+		const ignored = await isIgnored(gitignorePattern, {cwd});
 
 		const actual = [
 			'!!!unicorn.js',
 			'!!unicorn.js',
 			'!unicorn.js',
 			'unicorn.js',
-		].filter(file => !isIgnored(file));
+		].filter(file => !ignored(file));
 
 		const expected = ['!!unicorn.js', '!unicorn.js'];
 		t.deepEqual(actual, expected);
@@ -82,14 +84,14 @@ test('multiple negation', async t => {
 
 test('multiple negation - sync', t => {
 	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/multiple-negation'))) {
-		const isIgnored = isGitIgnoredSync({cwd});
+		const ignored = isIgnoredSync(gitignorePattern, {cwd});
 
 		const actual = [
 			'!!!unicorn.js',
 			'!!unicorn.js',
 			'!unicorn.js',
 			'unicorn.js',
-		].filter(file => !isIgnored(file));
+		].filter(file => !ignored(file));
 
 		const expected = ['!!unicorn.js', '!unicorn.js'];
 		t.deepEqual(actual, expected);
@@ -99,15 +101,15 @@ test('multiple negation - sync', t => {
 test('check file', async t => {
 	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	const ignoredFile = path.join(directory, 'foo.js');
-	const isIgnored = await isGitIgnored({cwd: directory});
-	const isIgnoredSync = isGitIgnoredSync({cwd: directory});
+	const ignored = await isIgnored(gitignorePattern, {cwd: directory});
+	const ignoredSync = isIgnoredSync(gitignorePattern, {cwd: directory});
 
 	for (const file of getPathValues(ignoredFile)) {
-		t.true(isIgnored(file));
-		t.true(isIgnoredSync(file));
+		t.true(ignored(file));
+		t.true(ignoredSync(file));
 	}
 
 	for (const file of getPathValues(path.join(directory, 'bar.js'))) {
-		t.false(isIgnored(file));
+		t.false(ignored(file));
 	}
 });


### PR DESCRIPTION
This is very similar to the `gitignore` option, except it allows globing for any compatible ignore file (eg, `.prettierignore` or `.eslintignore`). AMP had a recent need for this with our `prettier` integration, because it doesn't respect its ignore file when using the API directly.