### PR TITLE
Add return type for Stats

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,10 +89,13 @@ declare const globby: {
 	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
 	@returns The matching paths.
 	*/
-	sync: (
+	sync: ((
 		patterns: string | readonly string[],
-		options?: {stats: true} & globby.GlobbyOptions
-	) => Stats[];
+		options: globby.GlobbyOptions & { stats: true }
+	) => Stats[]) & ((
+		patterns: string | readonly string[],
+		options?: globby.GlobbyOptions
+	) => string[]);
 
 	/**
 	Find files and directories using glob patterns.
@@ -168,10 +171,13 @@ declare const globby: {
 	})();
 	```
 	*/
-	(
+	((
 		patterns: string | readonly string[],
-		options?: {stats: true} & globby.GlobbyOptions
-	): Promise<Stats[]>;
+		options: globby.GlobbyOptions & { stats: true }
+	) => Promise<Stats[]>) & ((
+		patterns: string | readonly string[],
+		options?: globby.GlobbyOptions
+	) => Promise<string[]>);
 };
 
 export = globby;

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,8 +91,8 @@ declare const globby: {
 	*/
 	sync: (
 		patterns: string | readonly string[],
-		options?: globby.GlobbyOptions
-	) => string[];
+		options?: {stats: true} & globby.GlobbyOptions
+	) => Stats[];
 
 	/**
 	Find files and directories using glob patterns.
@@ -170,8 +170,8 @@ declare const globby: {
 	*/
 	(
 		patterns: string | readonly string[],
-		options?: globby.GlobbyOptions
-	): Promise<string[] | Stats[]>;
+		options?: {stats: true} & globby.GlobbyOptions
+	): Promise<Stats[]>;
 };
 
 export = globby;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import {Options as FastGlobOptions} from 'fast-glob';
+import {Stats} from 'fs';
 
 declare namespace globby {
 	type ExpandDirectoriesOption =
@@ -170,7 +171,7 @@ declare const globby: {
 	(
 		patterns: string | readonly string[],
 		options?: globby.GlobbyOptions
-	): Promise<string[]>;
+	): Promise<string[] | Stats[]>;
 };
 
 export = globby;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,15 +12,15 @@ import {
 } from '.';
 
 // Globby
-expectType<Promise<string[]|Stats[]>>(globby('*.tmp'));
-expectType<Promise<string[]|Stats[]>>(globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
-expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {stats: true}));
+expectType<Promise<string[]>>(globby('*.tmp'));
+expectType<Promise<string[]>>(globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+expectType<Promise<Stats[]>>(globby('*.tmp', {stats: true}));
 
-expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {expandDirectories: false}));
-expectType<Promise<string[]|Stats[]>>(
+expectType<Promise<string[]>>(globby('*.tmp', {expandDirectories: false}));
+expectType<Promise<string[]>>(
 	globby('*.tmp', {expandDirectories: ['a*', 'b*']})
 );
-expectType<Promise<string[]|Stats[]>>(
+expectType<Promise<string[]>>(
 	globby('*.tmp', {
 		expandDirectories: {
 			files: ['a', 'b'],
@@ -28,12 +28,13 @@ expectType<Promise<string[]|Stats[]>>(
 		}
 	})
 );
-expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {gitignore: true}));
-expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {ignore: ['**/b.tmp']}));
+expectType<Promise<string[]>>(globby('*.tmp', {gitignore: true}));
+expectType<Promise<string[]>>(globby('*.tmp', {ignore: ['**/b.tmp']}));
 
 // Globby (sync)
 expectType<string[]>(globbySync('*.tmp'));
 expectType<string[]>(globbySync(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+expectType<Stats[]>(globbySync('*.tmp', {stats: true}));
 
 expectType<string[]>(globbySync('*.tmp', {expandDirectories: false}));
 expectType<string[]>(globbySync('*.tmp', {expandDirectories: ['a*', 'b*']}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,5 @@
 import {expectType} from 'tsd';
+import {Stats} from 'fs';
 import globby = require('.');
 import {
 	GlobTask,
@@ -11,14 +12,15 @@ import {
 } from '.';
 
 // Globby
-expectType<Promise<string[]>>(globby('*.tmp'));
-expectType<Promise<string[]>>(globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+expectType<Promise<string[]|Stats[]>>(globby('*.tmp'));
+expectType<Promise<string[]|Stats[]>>(globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {stats: true}));
 
-expectType<Promise<string[]>>(globby('*.tmp', {expandDirectories: false}));
-expectType<Promise<string[]>>(
+expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {expandDirectories: false}));
+expectType<Promise<string[]|Stats[]>>(
 	globby('*.tmp', {expandDirectories: ['a*', 'b*']})
 );
-expectType<Promise<string[]>>(
+expectType<Promise<string[]|Stats[]>>(
 	globby('*.tmp', {
 		expandDirectories: {
 			files: ['a', 'b'],
@@ -26,8 +28,8 @@ expectType<Promise<string[]>>(
 		}
 	})
 );
-expectType<Promise<string[]>>(globby('*.tmp', {gitignore: true}));
-expectType<Promise<string[]>>(globby('*.tmp', {ignore: ['**/b.tmp']}));
+expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {gitignore: true}));
+expectType<Promise<string[]|Stats[]>>(globby('*.tmp', {ignore: ['**/b.tmp']}));
 
 // Globby (sync)
 expectType<string[]>(globbySync('*.tmp'));

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Note that glob patterns can only contain forward-slashes, not backward-slashes, 
 
 ### globby(patterns, options?)
 
-Returns a `Promise<string[]>` of matching paths.
+Returns a `Promise<string[]|Stats[]>` of matching paths.
 
 #### patterns
 
@@ -91,7 +91,7 @@ Respect ignore patterns in `.gitignore` files that apply to the globbed files.
 
 ### globby.sync(patterns, options?)
 
-Returns `string[]` of matching paths.
+Returns `string[]|Stats[]` of matching paths.
 
 ### globby.stream(patterns, options?)
 


### PR DESCRIPTION
This is my first time adding types to an open source package so there might be some mistakes here. I took a go at fixing  https://github.com/sindresorhus/globby/issues/139

This should fix up the use case of that should be returning `Stats` instead of `string`.
```
globby('*.tmp', {stats: true});
```