### PR TITLE
Add types for stats option's overload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
 import {Options as FastGlobOptions} from 'fast-glob';
+import {Stats} from 'fs';
 
 declare namespace globby {
 	type ExpandDirectoriesOption =
 		| boolean
 		| readonly string[]
-		| {files?: readonly string[]; extensions?: readonly string[]};
+		| { files?: readonly string[]; extensions?: readonly string[] };
 
 	interface GlobbyOptions extends FastGlobOptions {
 		/**
@@ -86,12 +87,15 @@ declare const globby: {
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
-	@returns The matching paths.
+	@returns The matching paths - or the matching path's stats if the `stats` option is set.
 	*/
-	sync: (
+	sync: ((
+		patterns: string | readonly string[],
+		options: globby.GlobbyOptions & { stats: true }
+	) => Stats[]) & ((
 		patterns: string | readonly string[],
 		options?: globby.GlobbyOptions
-	) => string[];
+	) => string[]);
 
 	/**
 	Find files and directories using glob patterns.
@@ -167,6 +171,12 @@ declare const globby: {
 	})();
 	```
 	*/
+
+	(
+		patterns: string | readonly string[],
+		options: globby.GlobbyOptions & { stats: true }
+	): Promise<Stats[]>;
+
 	(
 		patterns: string | readonly string[],
 		options?: globby.GlobbyOptions

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare namespace globby {
 	type ExpandDirectoriesOption =
 		| boolean
 		| readonly string[]
-		| { files?: readonly string[]; extensions?: readonly string[] };
+		| {files?: readonly string[]; extensions?: readonly string[]};
 
 	interface GlobbyOptions extends FastGlobOptions {
 		/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,5 @@
 import {expectType} from 'tsd';
+import {Stats} from 'fs';
 import globby = require('.');
 import {
 	GlobTask,
@@ -13,6 +14,8 @@ import {
 // Globby
 expectType<Promise<string[]>>(globby('*.tmp'));
 expectType<Promise<string[]>>(globby(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+
+expectType<Promise<Stats[]>>(globby('*.tmp', {stats: true}));
 
 expectType<Promise<string[]>>(globby('*.tmp', {expandDirectories: false}));
 expectType<Promise<string[]>>(
@@ -45,6 +48,8 @@ expectType<string[]>(
 );
 expectType<string[]>(globbySync('*.tmp', {gitignore: true}));
 expectType<string[]>(globbySync('*.tmp', {ignore: ['**/b.tmp']}));
+
+expectType<Stats[]>(globbySync('*.tmp', {stats: true}));
 
 // Globby (stream)
 expectType<NodeJS.ReadableStream>(globbyStream('*.tmp'));


### PR DESCRIPTION
This PR adds the stats return type when the stats option is enabled. It overseeds https://github.com/sindresorhus/globby/pull/173.