### PR TITLE
Adding (e) for windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const checkCwdOption = (options = {}) => {
 	let stat;
 	try {
 		stat = fs.statSync(options.cwd);
-	} catch {
+	} catch(e) {
 		return;
 	}
 


### PR DESCRIPTION
Add (e) for windows wsl support in the catch statement to stop.
/node_modules/globby/index.js:28
        } catch {
                ^