### PR TITLE
Fix code example on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ $ npm install globby
 ```
 
 ```js
-import {globby} from 'globby';
+import globby from 'globby';
 
 const paths = await globby(['*', '!cake']);
 


### PR DESCRIPTION
It seems `import {globby} from 'globby';` should be `import globby from 'globby';` so I have removed the `{}`s.