### PR TITLE
Drop support for checking object with `path` property in function returns by `isGitIgnored`

### DIFF
--- a/gitignore.js
+++ b/gitignore.js
@@ -56,7 +56,7 @@ const ensureAbsolutePathForCwd = (cwd, p) => {
 	return path.join(cwd, p);
 };
 
-const getIsIgnoredPredicate = (ignores, cwd) => p => ignores.ignores(slash(path.relative(cwd, ensureAbsolutePathForCwd(cwd, toPath(p.path || p)))));
+const getIsIgnoredPredicate = (ignores, cwd) => p => ignores.ignores(slash(path.relative(cwd, ensureAbsolutePathForCwd(cwd, toPath(p)))));
 
 const getFile = async (file, cwd) => {
 	const filePath = path.join(cwd, file);

--- a/gitignore.test.js
+++ b/gitignore.test.js
@@ -127,9 +127,7 @@ test('check file', async t => {
 
 	for (const file of getPathValues(ignoredFile)) {
 		t.true(isIgnored(file));
-		t.true(isIgnored({path: file}));
 		t.true(isIgnoredSync(file));
-		t.true(isIgnoredSync({path: file}));
 	}
 
 	for (const file of getPathValues(path.join(directory, 'bar.js'))) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const checkCwdOption = options => {
 	}
 };
 
-const getPathString = p => p.stats instanceof fs.Stats ? p.path : p;
+const getPathString = fastGlobResult => fastGlobResult.path || fastGlobResult;
 
 export const generateGlobTasks = (patterns, taskOptions) => {
 	patterns = arrayUnion([patterns].flat());
@@ -101,7 +101,7 @@ const getFilter = async options => {
 	}
 
 	const filter = await isGitIgnored({cwd: options.cwd, ignore: options.ignore});
-	return fastGlobResult => filter(fastGlobResult.path || fastGlobResult);
+	return fastGlobResult => filter(getPathString(fastGlobResult));
 };
 
 const getFilterSync = options => {
@@ -110,7 +110,7 @@ const getFilterSync = options => {
 	}
 
 	const filter = isGitIgnoredSync({cwd: options.cwd, ignore: options.ignore});
-	return fastGlobResult => filter(fastGlobResult.path || fastGlobResult);
+	return fastGlobResult => filter(getPathString(fastGlobResult));
 };
 
 const globToTask = task => async glob => {
@@ -152,7 +152,7 @@ export const globby = async (patterns, options = {}) => {
 	const [filter, tasks] = await Promise.all([getFilter(options), getTasks()]);
 	const paths = await Promise.all(tasks.map(task => fastGlob(task.pattern, task.options)));
 
-	return arrayUnion(...paths).filter(path_ => !filter(getPathString(path_)));
+	return arrayUnion(...paths).filter(path_ => !filter(path_));
 };
 
 export const globbySync = (patterns, options = {}) => {


### PR DESCRIPTION
Ref: https://github.com/sindresorhus/globby/pull/207#issuecomment-1014263028

This behavior is never documented.