### PR TITLE
Simplify `expandDirectories` option handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,8 @@ const generateTasks = async (patterns, options) => {
 		return globTasks;
 	}
 
-	const dirGlobOptions = getDirGlobOptions(expandDirectories, cwd);
+	const patternExpandOptions = getDirGlobOptions(expandDirectories, cwd);
+	const ignoreExpandOptions = cwd ? {cwd} : undefined;
 
 	const tasks = await Promise.all(
 		globTasks.map(async task => {
@@ -118,8 +119,8 @@ const generateTasks = async (patterns, options) => {
 				patterns,
 				ignore,
 			] = await Promise.all([
-				dirGlob(pattern, dirGlobOptions),
-				dirGlob(options.ignore, cwd ? {cwd} : undefined),
+				dirGlob(pattern, patternExpandOptions),
+				dirGlob(options.ignore, ignoreExpandOptions),
 			]);
 
 			options.ignore = ignore;
@@ -139,12 +140,13 @@ const generateTasksSync = (patterns, options) => {
 		return globTasks;
 	}
 
-	const dirGlobOptions = getDirGlobOptions(expandDirectories, cwd);
+	const patternExpandOptions = getDirGlobOptions(expandDirectories, cwd);
+	const ignoreExpandOptions = cwd ? {cwd} : undefined;
 
 	return globTasks.flatMap(task => {
 		const {pattern, options} = task;
-		const patterns = dirGlob.sync(pattern, dirGlobOptions);
-		options.ignore = dirGlob.sync(options.ignore, cwd ? {cwd} : undefined);
+		const patterns = dirGlob.sync(pattern, patternExpandOptions);
+		options.ignore = dirGlob.sync(options.ignore, ignoreExpandOptions);
 		return patterns.map(pattern => ({pattern, options}));
 	});
 };

--- a/index.js
+++ b/index.js
@@ -94,9 +94,10 @@ const generateGlobTasksInternal = (patterns, taskOptions) => {
 	return globTasks;
 };
 
-const getDirGlobOptions = (options, cwd) => Array.isArray(options)
-	? {cwd, files: options}
-	: {...options, cwd};
+const getDirGlobOptions = (options, cwd) => ({
+	...(cwd ? {cwd} : {}),
+	...(Array.isArray(options) ? {files: options} : options),
+});
 
 const generateTasks = async (patterns, options) => {
 	const globTasks = generateGlobTasksInternal(patterns, options);
@@ -118,7 +119,7 @@ const generateTasks = async (patterns, options) => {
 				ignore,
 			] = await Promise.all([
 				dirGlob(pattern, dirGlobOptions),
-				dirGlob(options.ignore, {cwd}),
+				dirGlob(options.ignore, cwd ? {cwd} : undefined),
 			]);
 
 			options.ignore = ignore;
@@ -143,7 +144,7 @@ const generateTasksSync = (patterns, options) => {
 	return globTasks.flatMap(task => {
 		const {pattern, options} = task;
 		const patterns = dirGlob.sync(pattern, dirGlobOptions);
-		options.ignore = dirGlob.sync(options.ignore, {cwd});
+		options.ignore = dirGlob.sync(options.ignore, cwd ? {cwd} : undefined);
 		return patterns.map(pattern => ({pattern, options}));
 	});
 };


### PR DESCRIPTION
- Avoid normalizing `expandDirectories` repeatedly
- Pass  `cwd` when expanding `options.ignore`