### PR TITLE
Improve task expansion

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const generateTasks = async (patterns, options) => {
 	const patternExpandOptions = getDirGlobOptions(expandDirectories, cwd);
 	const ignoreExpandOptions = cwd ? {cwd} : undefined;
 
-	const tasks = await Promise.all(
+	return Promise.all(
 		globTasks.map(async task => {
 			const {pattern, options} = task;
 
@@ -124,11 +124,9 @@ const generateTasks = async (patterns, options) => {
 			]);
 
 			options.ignore = ignore;
-			return patterns.map(pattern => ({pattern, options}));
+			return {pattern: patterns, options};
 		}),
 	);
-
-	return tasks.flat();
 };
 
 const generateTasksSync = (patterns, options) => {
@@ -143,11 +141,11 @@ const generateTasksSync = (patterns, options) => {
 	const patternExpandOptions = getDirGlobOptions(expandDirectories, cwd);
 	const ignoreExpandOptions = cwd ? {cwd} : undefined;
 
-	return globTasks.flatMap(task => {
+	return globTasks.map(task => {
 		const {pattern, options} = task;
 		const patterns = dirGlob.sync(pattern, patternExpandOptions);
 		options.ignore = dirGlob.sync(options.ignore, ignoreExpandOptions);
-		return patterns.map(pattern => ({pattern, options}));
+		return {pattern: patterns, options};
 	});
 };
 


### PR DESCRIPTION
`fast-glob` accepts array as patterns, so we don't need flat tasks.

I'm not sure if this improves performance, but I don't think it will be slower.

In `generateGlobTasks` we can also avoid use multiple task, but I don't if worth to improve that part.

The benchmark test is broken, maybe I can tell if we fix that?