### PR TITLE
Expose new `generateGlobTasks` and `generateGlobTasksSync`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import {Options as FastGlobOptions, Entry} from 'fast-glob';
 export type GlobEntry = Entry;
 
 export interface GlobTask {
-	readonly pattern: string;
+	readonly patterns: string[];
 	readonly options: Options;
 }
 
@@ -139,6 +139,16 @@ Note that you should avoid running the same tasks multiple times as they contain
 @returns An object in the format `{pattern: string, options: object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
 */
 export function generateGlobTasks(
+	patterns: string | readonly string[],
+	options?: Options
+): Promise<GlobTask[]>;
+
+/**
+@see generateGlobTasks
+
+@returns An object in the format `{pattern: string, options: object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
+*/
+export function generateGlobTasksSync(
 	patterns: string | readonly string[],
 	options?: Options
 ): GlobTask[];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,6 +9,7 @@ import {
 	globbySync,
 	globbyStream,
 	generateGlobTasks,
+	generateGlobTasksSync,
 	isDynamicPattern,
 	isGitIgnored,
 	isGitIgnoredSync,
@@ -83,14 +84,14 @@ expectType<NodeJS.ReadableStream>(globbyStream('*.tmp', {ignore: ['**/b.tmp']}))
 })();
 
 // GenerateGlobTasks
-expectType<GlobTask[]>(generateGlobTasks('*.tmp'));
-expectType<GlobTask[]>(generateGlobTasks(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+expectType<Promise<GlobTask[]>>(generateGlobTasks('*.tmp'));
+expectType<Promise<GlobTask[]>>(generateGlobTasks(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
 
-expectType<GlobTask[]>(generateGlobTasks('*.tmp', {expandDirectories: false}));
-expectType<GlobTask[]>(
+expectType<Promise<GlobTask[]>>(generateGlobTasks('*.tmp', {expandDirectories: false}));
+expectType<Promise<GlobTask[]>>(
 	generateGlobTasks('*.tmp', {expandDirectories: ['a*', 'b*']}),
 );
-expectType<GlobTask[]>(
+expectType<Promise<GlobTask[]>>(
 	generateGlobTasks('*.tmp', {
 		expandDirectories: {
 			files: ['a', 'b'],
@@ -98,8 +99,27 @@ expectType<GlobTask[]>(
 		},
 	}),
 );
-expectType<GlobTask[]>(generateGlobTasks('*.tmp', {gitignore: true}));
-expectType<GlobTask[]>(generateGlobTasks('*.tmp', {ignore: ['**/b.tmp']}));
+expectType<Promise<GlobTask[]>>(generateGlobTasks('*.tmp', {gitignore: true}));
+expectType<Promise<GlobTask[]>>(generateGlobTasks('*.tmp', {ignore: ['**/b.tmp']}));
+
+// GenerateGlobTasksSync
+expectType<GlobTask[]>(generateGlobTasksSync('*.tmp'));
+expectType<GlobTask[]>(generateGlobTasksSync(['a.tmp', '*.tmp', '!{c,d,e}.tmp']));
+
+expectType<GlobTask[]>(generateGlobTasksSync('*.tmp', {expandDirectories: false}));
+expectType<GlobTask[]>(
+	generateGlobTasksSync('*.tmp', {expandDirectories: ['a*', 'b*']}),
+);
+expectType<GlobTask[]>(
+	generateGlobTasksSync('*.tmp', {
+		expandDirectories: {
+			files: ['a', 'b'],
+			extensions: ['tmp'],
+		},
+	}),
+);
+expectType<GlobTask[]>(generateGlobTasksSync('*.tmp', {gitignore: true}));
+expectType<GlobTask[]>(generateGlobTasksSync('*.tmp', {ignore: ['**/b.tmp']}));
 
 // IsDynamicPattern
 expectType<boolean>(isDynamicPattern('**'));

--- a/package.json
+++ b/package.json
@@ -81,5 +81,10 @@
 		"ignores": [
 			"fixtures"
 		]
+	},
+	"ava": {
+		"files": [
+			"!tests/utilities.js"
+		]
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -110,9 +110,15 @@ import {globbyStream} from 'globby';
 
 ### generateGlobTasks(patterns, options?)
 
-Returns an `object[]` in the format `{pattern: string, options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
+Returns an `Promise<object[]>` in the format `{patterns: string[], options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
 
 Note that you should avoid running the same tasks multiple times as they contain a file system cache. Instead, run this method each time to ensure file system changes are taken into consideration.
+
+### generateGlobTasksSync(patterns, options?)
+
+Returns an `object[]` in the format `{patterns: string[], options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
+
+Takes the same options as `generateGlobTasks`.
 
 ### isDynamicPattern(patterns, options?)
 

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Note that you should avoid running the same tasks multiple times as they contain
 
 Returns an `object[]` in the format `{patterns: string[], options: Object}`, which can be passed as arguments to [`fast-glob`](https://github.com/mrmlnc/fast-glob). This is useful for other globbing-related packages.
 
-Takes the same options as `generateGlobTasks`.
+Takes the same arguments as `generateGlobTasks`.
 
 ### isDynamicPattern(patterns, options?)
 

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -1,0 +1,43 @@
+import util from 'node:util';
+import test from 'ava';
+import {
+	generateGlobTasks,
+	generateGlobTasksSync,
+} from '../index.js';
+import {
+	invalidPatterns,
+} from './utilities.js';
+
+const runGenerateGlobTasks = async (t, patterns, options) => {
+	const promiseResult = await generateGlobTasks(patterns, options);
+	const syncResult = generateGlobTasksSync(patterns, options);
+
+	t.deepEqual(
+		promiseResult,
+		syncResult,
+		'generateGlobTasksSync() result is different than generateGlobTasks()',
+	);
+
+	return promiseResult;
+}
+
+test('generateGlobTasks', async t => {
+	const tasks = await runGenerateGlobTasks(t, ['*.tmp', '!b.tmp'], {ignore: ['c.tmp']});
+
+	t.is(tasks.length, 1);
+	t.deepEqual(tasks[0].patterns, ['*.tmp']);
+	t.deepEqual(tasks[0].options.ignore, ['c.tmp', 'b.tmp']);
+	await t.notThrowsAsync(generateGlobTasks('*'));
+	t.notThrows(() => generateGlobTasksSync('*'));
+});
+
+// Rejected for being an invalid pattern
+for (const value of invalidPatterns) {
+	const valueString = util.format(value);
+	const message = 'Patterns must be a string or an array of strings';
+
+	test(`throws for invalid patterns input: ${valueString}`, async t => {
+		await t.throwsAsync(generateGlobTasks(value), {instanceOf: TypeError, message});
+		t.throws(() => generateGlobTasksSync(value), {instanceOf: TypeError, message});
+	});
+}

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -57,7 +57,7 @@ test('throws when specifying a file as cwd', async t => {
 
 test('cwd', async t => {
 	const cwd = process.cwd();
-	for (const cwdDirectory of getPathValues()) {
+	for (const cwdDirectory of getPathValues(cwd)) {
 		// eslint-disable-next-line no-await-in-loop
 		const [task] = await runGenerateGlobTasks(t, ['*'], {cwd: cwdDirectory});
 		t.is(task.options.cwd, cwd);

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -1,4 +1,6 @@
 import util from 'node:util';
+import process from 'node:process';
+import path from 'node:path';
 import test from 'ava';
 import {
 	generateGlobTasks,
@@ -6,6 +8,7 @@ import {
 } from '../index.js';
 import {
 	invalidPatterns,
+	getPathValues,
 } from './utilities.js';
 
 const runGenerateGlobTasks = async (t, patterns, options) => {
@@ -19,7 +22,7 @@ const runGenerateGlobTasks = async (t, patterns, options) => {
 	);
 
 	return promiseResult;
-}
+};
 
 test('generateGlobTasks', async t => {
 	const tasks = await runGenerateGlobTasks(t, ['*.tmp', '!b.tmp'], {ignore: ['c.tmp']});
@@ -41,3 +44,58 @@ for (const value of invalidPatterns) {
 		t.throws(() => generateGlobTasksSync(value), {instanceOf: TypeError, message});
 	});
 }
+
+test('throws when specifying a file as cwd', async t => {
+	const error = {message: 'The `cwd` option must be a path to a directory'};
+
+	for (const file of getPathValues(path.resolve('fixtures/gitignore/bar.js'))) {
+		// eslint-disable-next-line no-await-in-loop
+		await t.throwsAsync(generateGlobTasks('*', {cwd: file}), error);
+		t.throws(() => generateGlobTasksSync('*', {cwd: file}), error);
+	}
+});
+
+test('cwd', async t => {
+	const cwd = process.cwd();
+	for (const cwdDirectory of getPathValues()) {
+		// eslint-disable-next-line no-await-in-loop
+		const [task] = await runGenerateGlobTasks(t, ['*'], {cwd: cwdDirectory});
+		t.is(task.options.cwd, cwd);
+	}
+});
+
+test('expandDirectories option', async t => {
+	{
+		const tasks = await runGenerateGlobTasks(t, ['fixtures'], {ignore: ['fixtures/negative']});
+		t.is(tasks.length, 1);
+		t.deepEqual(tasks[0].patterns, ['fixtures/**']);
+		t.deepEqual(tasks[0].options.ignore, ['fixtures/negative/**']);
+	}
+
+	{
+		const tasks = await runGenerateGlobTasks(t, ['fixtures'], {ignore: ['fixtures/negative'], expandDirectories: false});
+		t.is(tasks.length, 1);
+		t.deepEqual(tasks[0].patterns, ['fixtures']);
+		t.deepEqual(tasks[0].options.ignore, ['fixtures/negative']);
+	}
+
+	{
+		const tasks = await runGenerateGlobTasks(t, ['fixtures'], {expandDirectories: ['a*', 'b*']});
+		t.is(tasks.length, 1);
+		t.deepEqual(tasks[0].patterns, ['fixtures/**/a*', 'fixtures/**/b*']);
+		t.deepEqual(tasks[0].options.ignore, []);
+	}
+
+	{
+		const tasks = await runGenerateGlobTasks(t, ['fixtures'], {
+			expandDirectories: {
+				files: ['a', 'b*'],
+				extensions: ['tmp', 'txt'],
+			},
+			ignore: ['**/b.tmp'],
+		});
+		t.is(tasks.length, 1);
+		t.deepEqual(tasks[0].patterns, ['fixtures/**/a.{tmp,txt}', 'fixtures/**/b*.{tmp,txt}']);
+		t.deepEqual(tasks[0].options.ignore, ['**/b.tmp']);
+	}
+});

--- a/tests/gitignore.js
+++ b/tests/gitignore.js
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import slash from 'slash';
 import {isGitIgnored, isGitIgnoredSync} from '../gitignore.js';

--- a/tests/gitignore.js
+++ b/tests/gitignore.js
@@ -2,13 +2,14 @@ import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import slash from 'slash';
-import {isGitIgnored, isGitIgnoredSync} from './gitignore.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const getPathValues = cwd => [cwd, pathToFileURL(cwd)];
+import {isGitIgnored, isGitIgnoredSync} from '../gitignore.js';
+import {
+	PROJECT_ROOT,
+	getPathValues,
+} from './utilities.js';
 
 test('gitignore', async t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/gitignore'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
@@ -18,7 +19,7 @@ test('gitignore', async t => {
 });
 
 test('gitignore - mixed path styles', async t => {
-	const directory = path.join(__dirname, 'fixtures/gitignore');
+	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	for (const cwd of getPathValues(directory)) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd});
@@ -27,7 +28,7 @@ test('gitignore - mixed path styles', async t => {
 });
 
 test('gitignore - os paths', async t => {
-	const directory = path.join(__dirname, 'fixtures/gitignore');
+	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	for (const cwd of getPathValues(directory)) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd});
@@ -36,7 +37,7 @@ test('gitignore - os paths', async t => {
 });
 
 test('gitignore - sync', t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/gitignore'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
 		const isIgnored = isGitIgnoredSync({cwd});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
 		const expected = ['bar.js'];
@@ -47,7 +48,7 @@ test('gitignore - sync', t => {
 test('ignore ignored .gitignore', async t => {
 	const ignore = ['**/.gitignore'];
 
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/gitignore'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd, ignore});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
@@ -59,7 +60,7 @@ test('ignore ignored .gitignore', async t => {
 test('ignore ignored .gitignore - sync', t => {
 	const ignore = ['**/.gitignore'];
 
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/gitignore'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/gitignore'))) {
 		const isIgnored = isGitIgnoredSync({cwd, ignore});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
 		const expected = ['foo.js', 'bar.js'];
@@ -68,7 +69,7 @@ test('ignore ignored .gitignore - sync', t => {
 });
 
 test('negative gitignore', async t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/negative'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/negative'))) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
@@ -78,7 +79,7 @@ test('negative gitignore', async t => {
 });
 
 test('negative gitignore - sync', t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/negative'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/negative'))) {
 		const isIgnored = isGitIgnoredSync({cwd});
 		const actual = ['foo.js', 'bar.js'].filter(file => !isIgnored(file));
 		const expected = ['foo.js'];
@@ -87,7 +88,7 @@ test('negative gitignore - sync', t => {
 });
 
 test('multiple negation', async t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/multiple-negation'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/multiple-negation'))) {
 		// eslint-disable-next-line no-await-in-loop
 		const isIgnored = await isGitIgnored({cwd});
 
@@ -104,7 +105,7 @@ test('multiple negation', async t => {
 });
 
 test('multiple negation - sync', t => {
-	for (const cwd of getPathValues(path.join(__dirname, 'fixtures/multiple-negation'))) {
+	for (const cwd of getPathValues(path.join(PROJECT_ROOT, 'fixtures/multiple-negation'))) {
 		const isIgnored = isGitIgnoredSync({cwd});
 
 		const actual = [
@@ -120,7 +121,7 @@ test('multiple negation - sync', t => {
 });
 
 test('check file', async t => {
-	const directory = path.join(__dirname, 'fixtures/gitignore');
+	const directory = path.join(PROJECT_ROOT, 'fixtures/gitignore');
 	const ignoredFile = path.join(directory, 'foo.js');
 	const isIgnored = await isGitIgnored({cwd: directory});
 	const isIgnoredSync = isGitIgnoredSync({cwd: directory});

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -2,7 +2,6 @@ import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
-import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import getStream from 'get-stream';
 import {

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -10,10 +10,13 @@ import {
 	globbySync,
 	globbyStream,
 	isDynamicPattern,
-	generateGlobTasks,
-} from './index.js';
+} from '../index.js';
+import {
+	PROJECT_ROOT,
+	getPathValues,
+	invalidPatterns,
+} from './utilities.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const cwd = process.cwd();
 const temporary = 'tmp';
 
@@ -24,8 +27,6 @@ const fixture = [
 	'd.tmp',
 	'e.tmp',
 ];
-
-const getCwdValues = cwd => [cwd, pathToFileURL(cwd)];
 
 const stabilizeResult = result => result
 	.map(fastGlobResult => {
@@ -68,14 +69,14 @@ test.before(() => {
 
 	for (const element of fixture) {
 		fs.writeFileSync(element, '');
-		fs.writeFileSync(path.join(__dirname, temporary, element), '');
+		fs.writeFileSync(path.join(PROJECT_ROOT, temporary, element), '');
 	}
 });
 
 test.after(() => {
 	for (const element of fixture) {
 		fs.unlinkSync(element);
-		fs.unlinkSync(path.join(__dirname, temporary, element));
+		fs.unlinkSync(path.join(PROJECT_ROOT, temporary, element));
 	}
 
 	fs.rmdirSync(temporary);
@@ -123,28 +124,19 @@ test('don\'t mutate the options object - async', async t => {
 	t.pass();
 });
 
-test('expose generateGlobTasks', t => {
-	const tasks = generateGlobTasks(['*.tmp', '!b.tmp'], {ignore: ['c.tmp']});
-
-	t.is(tasks.length, 1);
-	t.is(tasks[0].pattern, '*.tmp');
-	t.deepEqual(tasks[0].options.ignore, ['c.tmp', 'b.tmp']);
-	t.notThrows(() => generateGlobTasks('*'));
-});
-
 test('expose isDynamicPattern', t => {
 	t.true(isDynamicPattern('**'));
 	t.true(isDynamicPattern(['**', 'path1', 'path2']));
 	t.false(isDynamicPattern(['path1', 'path2']));
 
-	for (const cwdDirectory of getCwdValues(cwd)) {
+	for (const cwdDirectory of getPathValues(cwd)) {
 		t.true(isDynamicPattern('**', {cwd: cwdDirectory}));
 	}
 });
 
 test('expandDirectories option', async t => {
 	t.deepEqual(await runGlobby(t, temporary), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
-	for (const temporaryDirectory of getCwdValues(temporary)) {
+	for (const temporaryDirectory of getPathValues(temporary)) {
 		// eslint-disable-next-line no-await-in-loop
 		t.deepEqual(await runGlobby(t, '**', {cwd: temporaryDirectory}), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
 	}
@@ -189,7 +181,7 @@ test('expandDirectories and ignores option', async t => {
 
 test.serial.failing('relative paths and ignores option', async t => {
 	process.chdir(temporary);
-	for (const cwd of getCwdValues(process.cwd())) {
+	for (const cwd of getPathValues(process.cwd())) {
 		// eslint-disable-next-line no-await-in-loop
 		t.deepEqual(await runGlobby(t, '../tmp', {
 			cwd,
@@ -201,32 +193,14 @@ test.serial.failing('relative paths and ignores option', async t => {
 });
 
 // Rejected for being an invalid pattern
-for (const value of [
-	{},
-	[{}],
-	true,
-	[true],
-	false,
-	[false],
-	null,
-	[null],
-	undefined,
-	[undefined],
-	Number.NaN,
-	[Number.NaN],
-	5,
-	[5],
-	function () {},
-	[function () {}],
-]) {
+for (const value of invalidPatterns) {
 	const valueString = util.format(value);
 	const message = 'Patterns must be a string or an array of strings';
 
 	test(`throws for invalid patterns input: ${valueString}`, async t => {
-		await t.throwsAsync(globby(t, value), {instanceOf: TypeError, message});
+		await t.throwsAsync(globby(value), {instanceOf: TypeError, message});
 		t.throws(() => globbySync(value), {instanceOf: TypeError, message});
 		t.throws(() => globbyStream(value), {instanceOf: TypeError, message});
-		t.throws(() => generateGlobTasks(value), {instanceOf: TypeError, message});
 		t.throws(() => isDynamicPattern(value), {instanceOf: TypeError, message});
 	});
 }
@@ -264,7 +238,7 @@ test('gitignore option and objectMode option', async t => {
 });
 
 test('`{extension: false}` and `expandDirectories.extensions` option', async t => {
-	for (const temporaryDirectory of getCwdValues(temporary)) {
+	for (const temporaryDirectory of getPathValues(temporary)) {
 		t.deepEqual(
 			// eslint-disable-next-line no-await-in-loop
 			await runGlobby(t, '*', {
@@ -291,7 +265,7 @@ test('`{extension: false}` and `expandDirectories.extensions` option', async t =
 test('throws when specifying a file as cwd', async t => {
 	const error = {message: 'The `cwd` option must be a path to a directory'};
 
-	for (const file of getCwdValues(path.resolve('fixtures/gitignore/bar.js'))) {
+	for (const file of getPathValues(path.resolve('fixtures/gitignore/bar.js'))) {
 		// eslint-disable-next-line no-await-in-loop
 		await t.throwsAsync(globby('.', {cwd: file}), error);
 		// eslint-disable-next-line no-await-in-loop
@@ -304,7 +278,7 @@ test('throws when specifying a file as cwd', async t => {
 });
 
 test('throws when specifying a file as cwd - isDynamicPattern', t => {
-	for (const file of getCwdValues(path.resolve('fixtures/gitignore/bar.js'))) {
+	for (const file of getPathValues(path.resolve('fixtures/gitignore/bar.js'))) {
 		t.throws(() => {
 			isDynamicPattern('.', {cwd: file});
 		}, {message: 'The `cwd` option must be a path to a directory'});
@@ -316,7 +290,7 @@ test('throws when specifying a file as cwd - isDynamicPattern', t => {
 });
 
 test('don\'t throw when specifying a non-existing cwd directory', async t => {
-	for (const cwd of getCwdValues('/unknown')) {
+	for (const cwd of getPathValues('/unknown')) {
 		// eslint-disable-next-line no-await-in-loop
 		const actual = await runGlobby(t, '.', {cwd});
 		t.is(actual.length, 0);

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -1,0 +1,23 @@
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import util from 'node:util';
+
+export const PROJECT_ROOT = fileURLToPath(new URL('../', import.meta.url));
+export const getPathValues = path => [path, pathToFileURL(path)];
+export const invalidPatterns = [
+	{},
+	[{}],
+	true,
+	[true],
+	false,
+	[false],
+	null,
+	[null],
+	undefined,
+	[undefined],
+	Number.NaN,
+	[Number.NaN],
+	5,
+	[5],
+	function () {},
+	[function () {}],
+];

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -1,5 +1,4 @@
 import {fileURLToPath, pathToFileURL} from 'node:url';
-import util from 'node:util';
 
 export const PROJECT_ROOT = fileURLToPath(new URL('../', import.meta.url));
 export const getPathValues = path => [path, pathToFileURL(path)];


### PR DESCRIPTION
The  old `generateGlobTasks` doesn't apply `expandDirectories` option.

I also changed `pattern` to `patterns`, I'm going to combine tasks with same options in a later PR.

If user want single pattern

```js
tasks.flatMap(({patterns, options}) => patterns.map(pattern => ({pattern, options})))
```