### PR TITLE
Improve performance with mutiple patterns

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import Benchmark from 'benchmark';
 import rimraf from 'rimraf';
-import * as globbyMainBranch from 'globby';
+import * as globbyMainBranch from '@globby/main-branch';
 import gs from 'glob-stream';
 import fastGlob from 'fast-glob';
 import {globby, globbySync, globbyStream} from './index.js';

--- a/index.js
+++ b/index.js
@@ -89,13 +89,14 @@ const convertNegativePatterns = (patterns, options) => {
 			task.options.ignore.push(ignorePattern);
 		}
 
-		const patternsBefore = patterns.splice(0, index);
 		if (index !== 0) {
 			tasks.push({
-				patterns: patternsBefore,
+				patterns: patterns.slice(0, index),
 				options: {...options, ignore: [...options.ignore, ignorePattern]},
 			});
 		}
+
+		patterns = patterns.slice(index + 1);
 	}
 
 	return tasks;

--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ const findIndexFrom = (array, callback, fromIndex) => {
 	return -1;
 };
 
-// TODO[@fisker]: Make this function returns `{patterns: string[], ignore: string[]}[]`
 const convertNegativePatterns = (patterns, options) => {
 	const tasks = [];
 

--- a/index.js
+++ b/index.js
@@ -55,9 +55,11 @@ const normalizeArgumentsSync = fn => (patterns, options) => fn(toPatternsArray(p
 const getFilter = async options => createFilterFunction(
 	options.gitignore && await isGitIgnored({cwd: options.cwd, ignore: options.ignore}),
 );
+
 const getFilterSync = options => createFilterFunction(
 	options.gitignore && isGitIgnoredSync({cwd: options.cwd, ignore: options.ignore}),
 );
+
 const createFilterFunction = isIgnored => {
 	const seen = new Set();
 
@@ -92,7 +94,13 @@ const convertNegativePatterns = (patterns, options) => {
 		if (index !== 0) {
 			tasks.push({
 				patterns: patterns.slice(0, index),
-				options: {...options, ignore: [...options.ignore, ignorePattern]},
+				options: {
+					...options,
+					ignore: [
+						...options.ignore,
+						ignorePattern
+					]
+				},
 			});
 		}
 

--- a/index.js
+++ b/index.js
@@ -105,20 +105,27 @@ const convertNegativePatterns = (patterns, options) => {
 	};
 
 	const tasks = [];
+	const addTask = (from, negativePatternIndex) => {
+		const ignorePattern = patterns[negativePatternIndex];
 
-	const patternsLength = patterns.length
-	let index = patterns.findIndex(isNegative);
-	if (index == -1) {
-		return [{patterns, options}];
+		for (const task of tasks) {
+			task.options.ignore.push(ignorePattern.slice(1));
+		}
+
+		if (negativePatternIndex === from + 1) {
+			return;
+		}
+
+		tasks.push({
+			patterns: patterns.slice(from + 1, negativePatternIndex),
+			options: createOptions(ignorePattern),
+		});
 	}
 
-	const patternsBefore = patterns.slice(0, index);
+	const patternsLength = patterns.length;
+	let index = -1;
 
-	if (index !== 0) {
-		tasks.push({patterns: patternsBefore, options: createOptions(patterns[index])});
-	}
-
-	while (index >= 0 && index < patternsLength - 1) {
+	while (index < patternsLength - 1) {
 		const nextNegativePatternIndex = findIndexFrom(patterns, isNegative, index + 1);
 
 		if (nextNegativePatternIndex === -1) {
@@ -126,18 +133,7 @@ const convertNegativePatterns = (patterns, options) => {
 			break;
 		}
 
-		const ignorePattern = patterns[nextNegativePatternIndex];
-
-		for (const task of tasks) {
-			task.options.ignore.push(ignorePattern.slice(1));
-		}
-
-		if (nextNegativePatternIndex !== index + 1) {
-			const patternsBetween = patterns.slice(index + 1, nextNegativePatternIndex);
-
-			tasks.push({patterns: patternsBetween, options: createOptions(ignorePattern)});
-		}
-
+		addTask(index, nextNegativePatternIndex);
 		index = nextNegativePatternIndex;
 	}
 

--- a/index.js
+++ b/index.js
@@ -75,32 +75,27 @@ const unionFastGlobStreams = (streams, filter) => merge2(streams).pipe(new Filte
 const convertNegativePatterns = (patterns, options) => {
 	const tasks = [];
 
-	for (let index = 0; index < patterns.length;) {
-		const restPatterns = patterns.slice(index);
-		const negativePatternIndex = restPatterns.findIndex(pattern => isNegative(pattern));
+	while (patterns.length > 0) {
+		const index = patterns.findIndex(pattern => isNegative(pattern));
 
-		if (negativePatternIndex === -1) {
-			tasks.push({patterns: restPatterns, options});
+		if (index === -1) {
+			tasks.push({patterns, options});
 			break;
 		}
 
-		const ignorePattern = restPatterns[negativePatternIndex].slice(1);
+		const ignorePattern = patterns[index].slice(1);
 
 		for (const task of tasks) {
 			task.options.ignore.push(ignorePattern);
 		}
 
-		if (negativePatternIndex !== 0) {
+		const patternsBefore = patterns.splice(0, index);
+		if (index !== 0) {
 			tasks.push({
-				patterns: restPatterns.slice(0, negativePatternIndex),
-				options: {
-					...options,
-					ignore: [...options.ignore, ignorePattern],
-				},
+				patterns: patternsBefore,
+				options: {...options, ignore: [...options.ignore, ignorePattern]},
 			});
 		}
-
-		index += negativePatternIndex + 1;
 	}
 
 	return tasks;

--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ const convertNegativePatterns = (patterns, options) => {
 					...options,
 					ignore: [
 						...options.ignore,
-						ignorePattern
-					]
+						ignorePattern,
+					],
 				},
 			});
 		}

--- a/index.js
+++ b/index.js
@@ -85,25 +85,6 @@ const findIndexFrom = (array, callback, fromIndex) => {
 // TODO[@fisker]: Make this function returns `{patterns: string[], ignore: string[]}[]`
 const convertNegativePatterns = (patterns, options) => {
 	const tasks = [];
-	const addTask = (from, negativePatternIndex) => {
-		const ignorePattern = patterns[negativePatternIndex].slice(1);
-
-		for (const task of tasks) {
-			task.options.ignore.push(ignorePattern);
-		}
-
-		if (negativePatternIndex === from) {
-			return;
-		}
-
-		tasks.push({
-			patterns: patterns.slice(from, negativePatternIndex),
-			options: {
-				...options,
-				ignore: [...options.ignore, ignorePattern],
-			},
-		});
-	};
 
 	for (let index = 0; index < patterns.length;) {
 		const nextNegativePatternIndex = findIndexFrom(patterns, isNegative, index);
@@ -113,7 +94,22 @@ const convertNegativePatterns = (patterns, options) => {
 			break;
 		}
 
-		addTask(index, nextNegativePatternIndex);
+		const ignorePattern = patterns[nextNegativePatternIndex].slice(1);
+
+		for (const task of tasks) {
+			task.options.ignore.push(ignorePattern);
+		}
+
+		if (nextNegativePatternIndex !== index) {
+			tasks.push({
+				patterns: patterns.slice(index, nextNegativePatternIndex),
+				options: {
+					...options,
+					ignore: [...options.ignore, ignorePattern],
+				},
+			});
+		}
+
 		index = nextNegativePatternIndex + 1;
 	}
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
-		"bench": "npm update globby glob-stream fast-glob && node bench.js",
+		"bench": "npm update @globby/main-branch glob-stream fast-glob && node bench.js",
 		"test": "xo && ava && tsd"
 	},
 	"files": [
@@ -66,12 +66,12 @@
 		"slash": "^4.0.0"
 	},
 	"devDependencies": {
+		"@globby/main-branch": "sindresorhus/globby#main",
 		"@types/node": "^16.11.11",
 		"ava": "^3.15.0",
 		"benchmark": "2.1.4",
 		"get-stream": "^6.0.1",
 		"glob-stream": "^7.0.0",
-		"globby": "sindresorhus/globby#main",
 		"rimraf": "^3.0.2",
 		"tsd": "^0.19.0",
 		"typescript": "^4.5.2",

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -146,7 +146,7 @@ test('random patterns', async t => {
 		const negativePatterns = [];
 		const negativePatternsAtStart = [];
 
-		const patterns = Array.from({length: 1 + (index % 10)}, (_, index) => {
+		const patterns = Array.from({length: 1 + Math.floor(Math.random() * 20)}, (_, index) => {
 			const negative = Math.random() > 0.5;
 			let pattern = String(index + 1);
 			if (negative) {

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -167,6 +167,12 @@ test('random patterns', async t => {
 		// eslint-disable-next-line no-await-in-loop
 		const tasks = await getTasks(t, patterns);
 		const patternsToDebug = JSON.stringify(patterns);
+
+		t.true(
+			tasks.length <= negativePatterns.length - negativePatternsAtStart.length + 1,
+			`Unexpected tasks: ${patternsToDebug}`,
+		);
+
 		for (const [index, {patterns, ignore}] of tasks.entries()) {
 			t.not(
 				patterns.length,

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -169,6 +169,7 @@ test('random patterns', async t => {
 		const tasks = await getTasks(t, patterns);
 		const patternsToDebug = JSON.stringify(patterns);
 		for (const {patterns, ignore} of tasks) {
+			t.not(patterns.length, 0, patternsToDebug);
 			t.true(isUnique(patterns), patternsToDebug);
 			t.true(isUnique(ignore), patternsToDebug);
 		}

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -167,7 +167,7 @@ test('random patterns', async t => {
 		// eslint-disable-next-line no-await-in-loop
 		const tasks = await getTasks(t, patterns);
 		const patternsToDebug = JSON.stringify(patterns);
-		for (const {patterns, ignore} of tasks) {
+		for (const [index, {patterns, ignore}] of tasks.entries()) {
 			t.not(
 				patterns.length,
 				0,
@@ -181,6 +181,14 @@ test('random patterns', async t => {
 				isUnique(ignore),
 				`ignore should be unique: ${patternsToDebug}`,
 			);
+
+			if (index !== 0 && ignore.length !== 0) {
+				t.deepEqual(
+					tasks[index - 1].ignore.slice(-ignore.length),
+					ignore,
+					`Unexpected ignore: ${patternsToDebug}`,
+				);
+			}
 		}
 
 		const allPatterns = tasks.flatMap(({patterns}) => patterns);
@@ -195,10 +203,6 @@ test('random patterns', async t => {
 			new Set(allIgnore).size,
 			negativePatterns.length - negativePatternsAtStart.length,
 			`negative patterns should be in ignore: ${patternsToDebug}`,
-		);
-		t.true(
-			tasks.every(({ignore}, index) => index === 0 || ignore.length < tasks[index - 1].ignore.length),
-			`ignore size should be greater then the next task: ${patternsToDebug}`,
 		);
 	}
 });

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -111,18 +111,22 @@ test('combine tasks', async t => {
 		await getTasks(t, ['a', 'b']),
 		[{patterns: ['a', 'b'], ignore: []}],
 	);
+
 	t.deepEqual(
 		await getTasks(t, ['!a', 'b']),
 		[{patterns: ['b'], ignore: []}],
 	);
+
 	t.deepEqual(
 		await getTasks(t, ['!a']),
 		[],
 	);
+
 	t.deepEqual(
 		await getTasks(t, ['a', 'b', '!c', '!d']),
 		[{patterns: ['a', 'b'], ignore: ['c', 'd']}],
 	);
+
 	t.deepEqual(
 		await getTasks(t, ['a', 'b', '!c', '!d', 'e']),
 		[
@@ -130,6 +134,7 @@ test('combine tasks', async t => {
 			{patterns: ['e'], ignore: []},
 		],
 	);
+
 	t.deepEqual(
 		await getTasks(t, ['a', 'b', '!c', 'd', 'e', '!f', '!g', 'h']),
 		[
@@ -179,10 +184,12 @@ test('random patterns', async t => {
 				0,
 				`Unexpected empty patterns: ${patternsToDebug}`,
 			);
+
 			t.true(
 				isUnique(patterns),
 				`patterns should be unique: ${patternsToDebug}`,
 			);
+
 			t.true(
 				isUnique(ignore),
 				`ignore should be unique: ${patternsToDebug}`,
@@ -205,6 +212,7 @@ test('random patterns', async t => {
 			positivePatterns.length,
 			`positive patterns should be in patterns: ${patternsToDebug}`,
 		);
+
 		t.is(
 			new Set(allIgnore).size,
 			negativePatterns.length - negativePatternsAtStart.length,

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -164,25 +164,41 @@ test('random patterns', async t => {
 			return pattern;
 		});
 
-		/* eslint-disable ava/assertion-arguments */
 		// eslint-disable-next-line no-await-in-loop
 		const tasks = await getTasks(t, patterns);
 		const patternsToDebug = JSON.stringify(patterns);
 		for (const {patterns, ignore} of tasks) {
-			t.not(patterns.length, 0, patternsToDebug);
-			t.true(isUnique(patterns), patternsToDebug);
-			t.true(isUnique(ignore), patternsToDebug);
+			t.not(
+				patterns.length,
+				0,
+				`Unexpected empty patterns: ${patternsToDebug}`,
+			);
+			t.true(
+				isUnique(patterns),
+				`patterns should be unique: ${patternsToDebug}`,
+			);
+			t.true(
+				isUnique(ignore),
+				`ignore should be unique: ${patternsToDebug}`,
+			);
 		}
 
 		const allPatterns = tasks.flatMap(({patterns}) => patterns);
 		const allIgnore = tasks.flatMap(({ignore}) => ignore);
 
-		t.is(new Set(allPatterns).size, positivePatterns.length, patternsToDebug);
+		t.is(
+			new Set(allPatterns).size,
+			positivePatterns.length,
+			`positive patterns should be in patterns: ${patternsToDebug}`,
+		);
 		t.is(
 			new Set(allIgnore).size,
 			negativePatterns.length - negativePatternsAtStart.length,
-			patternsToDebug,
+			`negative patterns should be in ignore: ${patternsToDebug}`,
 		);
-		/* eslint-enable ava/assertion-arguments */
+		t.true(
+			tasks.every(({ignore}, index) => index === 0 || ignore.length < tasks[index - 1].ignore.length),
+			`ignore size should be greater then the next task: ${patternsToDebug}`,
+		);
 	}
 });

--- a/tests/generate-glob-tasks.js
+++ b/tests/generate-glob-tasks.js
@@ -182,7 +182,7 @@ test('random patterns', async t => {
 				`ignore should be unique: ${patternsToDebug}`,
 			);
 
-			if (index !== 0 && ignore.length !== 0) {
+			if (index !== 0 && ignore.length > 0) {
 				t.deepEqual(
 					tasks[index - 1].ignore.slice(-ignore.length),
 					ignore,

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -14,6 +14,7 @@ import {
 	PROJECT_ROOT,
 	getPathValues,
 	invalidPatterns,
+	isUnique,
 } from './utilities.js';
 
 const cwd = process.cwd();
@@ -298,6 +299,5 @@ test('don\'t throw when specifying a non-existing cwd directory', async t => {
 
 test('unique when using objectMode option', async t => {
 	const result = await runGlobby(t, ['a.tmp', '*.tmp'], {cwd, objectMode: true});
-	const isUnique = array => [...new Set(array)].length === array.length;
 	t.true(isUnique(result.map(({path}) => path)));
 });

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -20,3 +20,4 @@ export const invalidPatterns = [
 	function () {},
 	[function () {}],
 ];
+export const isUnique = array => new Set(array).size === array.length;

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -1,7 +1,9 @@
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
 export const PROJECT_ROOT = fileURLToPath(new URL('../', import.meta.url));
+
 export const getPathValues = path => [path, pathToFileURL(path)];
+
 export const invalidPatterns = [
 	{},
 	[{}],
@@ -20,4 +22,5 @@ export const invalidPatterns = [
 	function () {},
 	[function () {}],
 ];
+
 export const isUnique = array => new Set(array).size === array.length;


### PR DESCRIPTION
Combine tasks with same options.

Test with this pattern `['**/eslint-plugin-*/package.json', '**/@*/eslint-plugin/package.json']`, [Prettier use a similar pattern to search plugins](https://github.com/prettier/prettier/blob/db73cc8e0c9e3e565cf4f5e9eceaa6b7e90b48e4/src/common/load-plugins.js#L106-L110).

```text
main - sync: 1.992s
working - sync: 990.913ms
main - async: 1.059s
working - async: 490.155ms
main - stream: 973.486ms
working - stream: 595.946ms
```