### PR TITLE
Don't pass `options.ignore` to `isGitIgnored`

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ const normalizeArguments = fn => async (patterns, options) => fn(toPatternsArray
 const normalizeArgumentsSync = fn => (patterns, options) => fn(toPatternsArray(patterns), normalizeOptions(options));
 
 const getFilter = async options => createFilterFunction(
-	options.gitignore && await isGitIgnored({cwd: options.cwd, ignore: options.ignore}),
+	options.gitignore && await isGitIgnored({cwd: options.cwd}),
 );
 const getFilterSync = options => createFilterFunction(
-	options.gitignore && isGitIgnoredSync({cwd: options.cwd, ignore: options.ignore}),
+	options.gitignore && isGitIgnoredSync({cwd: options.cwd}),
 );
 const createFilterFunction = isIgnored => {
 	const seen = new Set();


### PR DESCRIPTION
`ignore` option in `isGitIgnored()` mean to ignore `.gitignore` files,  but when running `globby()`, `ignore` mean to ignore matched files.

For example:

```js
globbySync('**/*', {gitignore: true, ignore: ['.gitignore']})
```

This mean to glob all files that's not `gitignore`d, but except `.gitignore` file, not mean don't read the `.gitignore` file.

Before:

```text
> globbySync('**/*', {gitignore: true, ignore: ['.gitignore']}).filter(file => file.startsWith('node_modules')).length
11662
```

After:

```text
> globbySync('**/*', {gitignore: true, ignore: ['.gitignore']}).filter(file => file.startsWith('node_modules')).length
0
```

This is a little hard to test, I didn't add.

