### PR TITLE
Fix duplicated result when using globstar

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import nodePath from 'node:path';
 import merge2 from 'merge2';
 import fastGlob from 'fast-glob';
 import dirGlob from 'dir-glob';
@@ -84,8 +85,9 @@ const createFilterFunction = isIgnored => {
 
 	return fastGlobResult => {
 		const path = fastGlobResult.path || fastGlobResult;
-		const seenOrIgnored = seen.has(path) || (isIgnored && isIgnored(path));
-		seen.add(path);
+		const pathKey = nodePath.normalize(path);
+		const seenOrIgnored = seen.has(pathKey) || (isIgnored && isIgnored(path));
+		seen.add(pathKey);
 		return !seenOrIgnored;
 	};
 };

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -116,6 +116,13 @@ test('glob - stream async iterator support', async t => {
 	t.deepEqual(results, ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);
 });
 
+test('glob - duplicated patterns', async t => {
+	const result1 = await runGlobby(t, [`./${temporary}/**`, `./${temporary}`]);
+	t.deepEqual(result1, ['./tmp/a.tmp', './tmp/b.tmp', './tmp/c.tmp', './tmp/d.tmp', './tmp/e.tmp']);
+	const result2 = await runGlobby(t, [`./${temporary}`, `./${temporary}/**`]);
+	t.deepEqual(result2, ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
+});
+
 test.serial('cwd option', async t => {
 	process.chdir(temporary);
 	t.deepEqual(await runGlobby(t, '*.tmp', {cwd}), ['a.tmp', 'b.tmp', 'c.tmp', 'd.tmp', 'e.tmp']);


### PR DESCRIPTION
Fixes #175.

I updated `createFilterFunction` using normalized path string instead of just path.

So, the below code lines return the commented values instead of `[ 'a/b', './a/b' ]`.

```js
// below code returns [ './a/b' ]
console.log(globbySync(['./a/**', './a']));

// below code returns [ 'a/b' ]
console.log(globbySync(['./a', './a/**']));
```