### PR TITLE
Make ignoreFiles option accept readonly arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ export interface Options extends FastGlobOptionsWithoutCwd {
 
 	@default undefined
 	*/
-	readonly ignoreFiles?: string | string[];
+	readonly ignoreFiles?: string | readonly string[];
 
 	/**
 	The current working directory in which to search.


### PR DESCRIPTION
As the code has no need to mutate this array, it makes sense that it should accept readonly arrays. This avoids unnecessary slicing/spreading to ensure readonly arrays in calling code can be accepted.