### PR TITLE
Add cache to `isGitIgnored` and `isGitIgnoredSync`

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -77,7 +77,7 @@ export const isIgnoredByIgnoreFiles = async (patterns, options) => {
 			})),
 		);
 
-		cache.set(cacheKey, getIsIgnoredPredicate(files, cwd))
+		cache.set(cacheKey, getIsIgnoredPredicate(files, cwd));
 	}
 
 	return cache.get(cacheKey);
@@ -95,7 +95,7 @@ export const isIgnoredByIgnoreFilesSync = (patterns, options) => {
 			content: fs.readFileSync(filePath, 'utf8'),
 		}));
 
-		cache.set(cacheKey, getIsIgnoredPredicate(files, cwd))
+		cache.set(cacheKey, getIsIgnoredPredicate(files, cwd));
 	}
 
 	return cache.get(cacheKey);

--- a/index.js
+++ b/index.js
@@ -8,19 +8,12 @@ import {
 	isIgnoredByIgnoreFiles,
 	isIgnoredByIgnoreFilesSync,
 } from './ignore.js';
-import {FilterStream, toPath, isNegativePattern} from './utilities.js';
-
-const assertPatternsInput = patterns => {
-	if (patterns.some(pattern => typeof pattern !== 'string')) {
-		throw new TypeError('Patterns must be a string or an array of strings');
-	}
-};
-
-const toPatternsArray = patterns => {
-	patterns = [...new Set([patterns].flat())];
-	assertPatternsInput(patterns);
-	return patterns;
-};
+import {
+	FilterStream,
+	toPath,
+	isNegativePattern,
+	toPatternsArray,
+} from './utilities.js';
 
 const checkCwdOption = options => {
 	if (!options.cwd) {

--- a/utilities.js
+++ b/utilities.js
@@ -14,4 +14,16 @@ export class FilterStream extends Transform {
 	}
 }
 
+const assertPatternsInput = patterns => {
+	if (patterns.some(pattern => typeof pattern !== 'string')) {
+		throw new TypeError('Patterns must be a string or an array of strings');
+	}
+};
+
+export const toPatternsArray = patterns => {
+	patterns = [...new Set([patterns].flat())];
+	assertPatternsInput(patterns);
+	return patterns;
+};
+
 export const isNegativePattern = pattern => pattern[0] === '!';


### PR DESCRIPTION
I was running `xo` in `eslint-plugin-unicorn` project, and found it's very slow. So I add some debug info

```text
eslint.isPathIgnored: 0.097ms
micromatch.isMatch: 0.247ms
isGitIgnoredSync: 2.774s
eslint.isPathIgnored: 0.138ms
micromatch.isMatch: 0.537ms
isGitIgnoredSync: 2.396s
eslint.isPathIgnored: 0.091ms
micromatch.isMatch: 0.245ms
isGitIgnoredSync: 2.709s
eslint.isPathIgnored: 0.107ms
micromatch.isMatch: 0.331ms
isGitIgnoredSync: 2.806s
eslint.isPathIgnored: 0.176ms
micromatch.isMatch: 0.543ms
isGitIgnoredSync: 2.408s
eslint.isPathIgnored: 0.14ms
micromatch.isMatch: 0.579ms
```

And found `isGitIgnoredSync` is very slow. It keeps glob and read `.gitignore` file again and again.

After this 


```text
isGitIgnoredSync: 0.1ms
eslint.isPathIgnored: 0.193ms
micromatch.isMatch: 0.197ms
isGitIgnoredSync: 0.051ms
eslint.isPathIgnored: 0.074ms
micromatch.isMatch: 0.248ms
isGitIgnoredSync: 0.151ms
eslint.isPathIgnored: 0.118ms
micromatch.isMatch: 0.454ms
isGitIgnoredSync: 0.109ms
eslint.isPathIgnored: 0.077ms
micromatch.isMatch: 0.223ms
isGitIgnoredSync: 0.037ms
eslint.isPathIgnored: 0.074ms
micromatch.isMatch: 0.244ms
isGitIgnoredSync: 0.091ms
```

Problem is how should we process this? Add an option? Add a new `createIsGitIgnored` function? Or just cache the result?