### PR TITLE
Fixes exception in a top path edge case

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -52,7 +52,7 @@ const getIsIgnoredPredicate = (files, cwd) => {
 	return fileOrDirectory => {
 		fileOrDirectory = toPath(fileOrDirectory);
 		fileOrDirectory = toRelativePath(fileOrDirectory, cwd);
-		return fileOrDirectory && ignores.ignores(slash(fileOrDirectory));
+		return fileOrDirectory ? ignores.ignores(slash(fileOrDirectory)) : false;
 	};
 };
 

--- a/ignore.js
+++ b/ignore.js
@@ -52,7 +52,7 @@ const getIsIgnoredPredicate = (files, cwd) => {
 	return fileOrDirectory => {
 		fileOrDirectory = toPath(fileOrDirectory);
 		fileOrDirectory = toRelativePath(fileOrDirectory, cwd);
-		return ignores.ignores(slash(fileOrDirectory));
+		return fileOrDirectory && ignores.ignores(slash(fileOrDirectory));
 	};
 };
 

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -190,6 +190,16 @@ test('expandDirectories and ignores option', async t => {
 	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
+test('absolute:true, expandDirectories:false, onlyFiles:false, gitignore:true and top level folder', async t => {
+	t.deepEqual(await runGlobby(t, '.', {
+		absolute: true,
+		cwd: path.resolve(temporary),
+		expandDirectories: false,
+		gitignore: true,
+		onlyFiles: false,
+	}), [path.resolve(temporary)]);
+});
+
 test.serial.failing('relative paths and ignores option', async t => {
 	process.chdir(temporary);
 	for (const cwd of getPathValues(process.cwd())) {

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -191,13 +191,16 @@ test('expandDirectories and ignores option', async t => {
 });
 
 test('absolute:true, expandDirectories:false, onlyFiles:false, gitignore:true and top level folder', async t => {
-	t.deepEqual(await runGlobby(t, '.', {
+	const result = await runGlobby(t, '.', {
 		absolute: true,
 		cwd: path.resolve(temporary),
 		expandDirectories: false,
 		gitignore: true,
 		onlyFiles: false,
-	}), [path.resolve(temporary)]);
+	});
+
+	t.is(result.length, 1);
+	t.truthy(result[0].endsWith(temporary));
 });
 
 test.serial.failing('relative paths and ignores option', async t => {


### PR DESCRIPTION
The gitignore is throwing an exception when dealing with absolute paths if that path is the very same as the working directory.

This is the case when both `expandDirectories: false` and `onlyFiles: false` are set and the input is `.` and the `cwd` is set to an absolute path.

I ran across this when using `globby` in a project of mine and I reproduced it with a test case here and then fixed it.