### PR TITLE
Also run CI on Node 18 + update used workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
           - 16
           - 14
         os:
@@ -17,8 +18,8 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
As Node 18 is an LTS, it should be tested on now as well.

While adding that I also noticed that the two workflows used here was using v2 rather than the latest v3, so I updated those as well.