### PR TITLE
Pass deep option to ignore filter to avoid unnecessary recursion

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -59,12 +59,13 @@ const getIsIgnoredPredicate = (files, cwd) => {
 const normalizeOptions = (options = {}) => ({
 	cwd: toPath(options.cwd) || process.cwd(),
 	suppressErrors: Boolean(options.suppressErrors),
+	deep: options.deep ? Number.parseInt(options.deep, 10) : Number.POSITIVE_INFINITY,
 });
 
 export const isIgnoredByIgnoreFiles = async (patterns, options) => {
-	const {cwd, suppressErrors} = normalizeOptions(options);
+	const {cwd, suppressErrors, deep} = normalizeOptions(options);
 
-	const paths = await fastGlob(patterns, {cwd, suppressErrors, ...ignoreFilesGlobOptions});
+	const paths = await fastGlob(patterns, {cwd, suppressErrors, deep, ...ignoreFilesGlobOptions});
 
 	const files = await Promise.all(
 		paths.map(async filePath => ({
@@ -77,9 +78,9 @@ export const isIgnoredByIgnoreFiles = async (patterns, options) => {
 };
 
 export const isIgnoredByIgnoreFilesSync = (patterns, options) => {
-	const {cwd, suppressErrors} = normalizeOptions(options);
+	const {cwd, suppressErrors, deep} = normalizeOptions(options);
 
-	const paths = fastGlob.sync(patterns, {cwd, suppressErrors, ...ignoreFilesGlobOptions});
+	const paths = fastGlob.sync(patterns, {cwd, suppressErrors, deep, ...ignoreFilesGlobOptions});
 
 	const files = paths.map(filePath => ({
 		filePath,

--- a/ignore.js
+++ b/ignore.js
@@ -59,7 +59,7 @@ const getIsIgnoredPredicate = (files, cwd) => {
 const normalizeOptions = (options = {}) => ({
 	cwd: toPath(options.cwd) || process.cwd(),
 	suppressErrors: Boolean(options.suppressErrors),
-	deep: options.deep ? Number.parseInt(options.deep, 10) : Number.POSITIVE_INFINITY,
+	deep: typeof options.deep === 'number' ? options.deep : Number.POSITIVE_INFINITY,
 });
 
 export const isIgnoredByIgnoreFiles = async (patterns, options) => {


### PR DESCRIPTION
When globbing through a very large directory, it's useful to use the `deep` option from `fast-glob` to stop at a maximum level of depth: https://github.com/mrmlnc/fast-glob#deep

However when using `gitignore: true`, the lookup for ignored files doesn't currently pass the `deep` option, meaning that we still go through every level of the directory.

This PR forwards the `deep` option to make it work as expected.