### PR TITLE
Fix `ignore` and `expandDirectories` default handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,9 +41,11 @@ const checkCwdOption = options => {
 
 const normalizeOptions = (options = {}) => {
 	options = {
-		ignore: [],
-		expandDirectories: true,
 		...options,
+		ignore: options.ignore || [],
+		expandDirectories: options.expandDirectories === undefined
+			? true
+			: options.expandDirectories,
 		cwd: toPath(options.cwd),
 	};
 


### PR DESCRIPTION
Hey folks! I'm working on a CLI that forwards options from [util.parseArgs](https://nodejs.org/api/util.html#utilparseargsconfig) to `globby` and encountered a runtime error when `undefined` is passed to the `ignore` option. While investigating the error I found that both the `ignore` and `expandDirectories` defaults  are overridden when `undefined` is passed. I've included this same patch in my program so feel free to close this PR if the existing behavior is expected 👋 