### PR TITLE
Fix read permission error on ignore files search

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -8,13 +8,13 @@ import slash from 'slash';
 import {toPath} from 'unicorn-magic';
 import {isNegativePattern} from './utilities.js';
 
+const defaultIgnoredDirectories = [
+	'**/node_modules',
+	'**/flow-typed',
+	'**/coverage',
+	'**/.git',
+];
 const ignoreFilesGlobOptions = {
-	ignore: [
-		'**/node_modules',
-		'**/flow-typed',
-		'**/coverage',
-		'**/.git',
-	],
 	absolute: true,
 	dot: true,
 };
@@ -62,12 +62,13 @@ const normalizeOptions = (options = {}) => ({
 	cwd: toPath(options.cwd) ?? process.cwd(),
 	suppressErrors: Boolean(options.suppressErrors),
 	deep: typeof options.deep === 'number' ? options.deep : Number.POSITIVE_INFINITY,
+	ignore: [...options.ignore ?? [], ...defaultIgnoredDirectories],
 });
 
 export const isIgnoredByIgnoreFiles = async (patterns, options) => {
-	const {cwd, suppressErrors, deep} = normalizeOptions(options);
+	const {cwd, suppressErrors, deep, ignore} = normalizeOptions(options);
 
-	const paths = await fastGlob(patterns, {cwd, suppressErrors, deep, ...ignoreFilesGlobOptions});
+	const paths = await fastGlob(patterns, {cwd, suppressErrors, deep, ignore, ...ignoreFilesGlobOptions});
 
 	const files = await Promise.all(
 		paths.map(async filePath => ({
@@ -80,9 +81,9 @@ export const isIgnoredByIgnoreFiles = async (patterns, options) => {
 };
 
 export const isIgnoredByIgnoreFilesSync = (patterns, options) => {
-	const {cwd, suppressErrors, deep} = normalizeOptions(options);
+	const {cwd, suppressErrors, deep, ignore} = normalizeOptions(options);
 
-	const paths = fastGlob.sync(patterns, {cwd, suppressErrors, deep, ...ignoreFilesGlobOptions});
+	const paths = fastGlob.sync(patterns, {cwd, suppressErrors, deep, ignore, ...ignoreFilesGlobOptions});
 
 	const files = paths.map(filePath => ({
 		filePath,

--- a/tests/ignore.js
+++ b/tests/ignore.js
@@ -1,3 +1,4 @@
+import {chmod} from 'node:fs/promises';
 import path from 'node:path';
 import test from 'ava';
 import slash from 'slash';
@@ -185,4 +186,22 @@ test('custom ignore files', async t => {
 			'ignored-by-prettier.js',
 		],
 	);
+});
+
+test.serial('bad permissions', async t => {
+	const cwd = path.join(PROJECT_ROOT, 'fixtures/bad-permissions');
+	const noReadDirectory = path.join(cwd, 'noread');
+
+	await chmod(noReadDirectory, 0o000);
+
+	await t.notThrowsAsync(
+		runIsIgnoredByIgnoreFiles(
+			t,
+			'**/*',
+			{cwd, ignore: ['noread']},
+			() => {},
+		),
+	);
+
+	t.teardown(() => chmod(noReadDirectory, 0o755));
 });


### PR DESCRIPTION
This PR should fix #254 and fix #258. As well as `xo`’s [#737](https://github.com/xojs/xo/issues/737) when `globby`’s dependency gets upgraded.

It allows to forward the `ignore` option field passed to `globby`’s `isIgnoredByIgnoreFiles` to `fast-glob`.

To give some more context, this function is used to find all `.gitignore` files relative to the current working directory. If any subdirectory of the current working directory is not readable, `fast-glob` exits with an error.

By forwarding the `ignore` option to `fast-glob` when searching for ignore files, we prevent this behavior.

A few things that should be considered before this gets merged:

**Documentation**

There are currently no docs about this, but since the readme file mentions that the `options` object extends the `fast-glob` options, I’m not sure if it’s worth to document.

**Tests**

When a directory is not readable, the behavior of `fast-glob` is to **exit**, not to _throw_.
So, if we remove the `ignore` option of the test, `ava` will fail **all** tests run with the following error:

```
Exiting due to process.exit() when running tests/ignore.js
```

Some side nodes about the test:
- `.notThrowsAsync` is used, but as said above: `fast-glob` doesn’t throw, it exits ; so this might be wrong. You tell me
- `.serial` is used to prevent other tests to fail because of the bad directory permissions
- `.teardown` is used to revert the directory permissions to something readable