### PR TITLE
fix glob expandDirectories extension option gen glob

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const getDirectoryGlob = ({directoryPath, files, extensions}) => {
 	const extensionGlob = extensions?.length > 0 ? `.${extensions.length > 1 ? `{${extensions.join(',')}}` : extensions[0]}` : '';
 	return files
 		? files.map(file => nodePath.posix.join(directoryPath, `**/${nodePath.extname(file) ? file : `${file}${extensionGlob}`}`))
-		: [nodePath.posix.join(directoryPath, `**${extensionGlob ? `/${extensionGlob}` : ''}`)];
+		: [nodePath.posix.join(directoryPath, `**${extensionGlob ? `/*${extensionGlob}` : ''}`)];
 };
 
 const directoryToGlob = async (directoryPaths, {

--- a/tests/globby.js
+++ b/tests/globby.js
@@ -165,6 +165,11 @@ test('expandDirectories option', async t => {
 		},
 		ignore: ['**/b.tmp'],
 	}), ['tmp/a.tmp']);
+	t.deepEqual(await runGlobby(t, temporary, {
+		expandDirectories: {
+			extensions: ['tmp'],
+		},
+	}), ['tmp/a.tmp', 'tmp/b.tmp', 'tmp/c.tmp', 'tmp/d.tmp', 'tmp/e.tmp']);
 });
 
 test('expandDirectories:true and onlyFiles:true option', async t => {


### PR DESCRIPTION
When only set `extensions` option for `expandDirectories` like
```js
const res = await globby(["tests"], {
  expandDirectories: {
     extensions: ["js"],
  },
});
console.log(res);
```
it gets an empty array even with js files existing because `getDirectoryGlob`generates `tests/**/.js` pattern which is invalid.