### PR TITLE
Do not ignore pattern start with `./`

### DIFF
--- a/fixtures/gitignore/.gitignore
+++ b/fixtures/gitignore/.gitignore
@@ -1,2 +1,3 @@
 foo.js
 !bar.js
+./baz.js

--- a/ignore.js
+++ b/ignore.js
@@ -30,7 +30,7 @@ const parseIgnoreFile = (file, cwd) => {
 
 	return file.content
 		.split(/\r?\n/)
-		.filter(line => line && !line.startsWith('#'))
+		.filter(line => line && !line.startsWith('#') && !line.startsWith('./') && !line.startsWith('../'))
 		.map(pattern => applyBaseToPattern(pattern, base));
 };
 

--- a/tests/ignore.js
+++ b/tests/ignore.js
@@ -51,9 +51,9 @@ test('ignore', async t => {
 		const actual = await runIsGitIgnored(
 			t,
 			{cwd},
-			isIgnored => ['foo.js', 'bar.js'].filter(file => !isIgnored(file)),
+			isIgnored => ['foo.js', 'bar.js', 'baz.js'].filter(file => !isIgnored(file)),
 		);
-		const expected = ['bar.js'];
+		const expected = ['bar.js', 'baz.js'];
 		t.deepEqual(actual, expected);
 	}
 });


### PR DESCRIPTION
This PR fix 2 issues:

### ~~Issue 1: trim gitignore file content~~

### Issue 2: pattern starts with `./` or `./` should not be ignored

```
foo
├── .gitignore ---> content: ./bar.js
└── bar.js ---> should not be ignored, but actually ignored by globby
```