### PR TITLE
Export `isIgnoredByIgnoreFiles` and `isIgnoredByIgnoreFilesSync` functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -207,39 +207,39 @@ export function isGitIgnoredSync(options?: GitignoreOptions): GlobbyFilterFuncti
 export function convertPathToPattern(source: string): FastGlob.Pattern;
 
 /**
- * Check if a path is ignored by the ignore files.
- * @param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
- * @param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
- *
- * @returns A filter function indicating whether a given path is ignored via the ignore files.
- *
- * @example
- * ```
- * import {isIgnoredByIgnoreFiles} from 'globby';
- *
- * const isIgnored = await isIgnoredByIgnoreFiles('**\/.gitignore');
- *
- * console.log(isIgnored('some/file'));
- * ```
- */
+Check if a path is ignored by the ignore files.
+@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
+@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
+
+@returns A filter function indicating whether a given path is ignored via the ignore files.
+
+@example
+```
+import {isIgnoredByIgnoreFiles} from 'globby';
+
+const isIgnored = await isIgnoredByIgnoreFiles('**\/.gitignore');
+
+console.log(isIgnored('some/file'));
+```
+*/
 export function isIgnoredByIgnoreFiles(
 	patterns: string | readonly string[],
 	options?: Options
 ): Promise<GlobbyFilterFunction>;
 
 /**
- * Check if a path is ignored by the ignore files.
- * @see {@link isIgnoredByIgnoreFiles}
- *
- * @example
- * ```js
- * import {isIgnoredByIgnoreFilesSync} from 'globby';
- *
- * const isIgnored = isIgnoredByIgnoreFilesSync('**\/.gitignore');
- *
- * console.log(isIgnored('some/file'));
- * ```
- */
+Check if a path is ignored by the ignore files.
+@see {@link isIgnoredByIgnoreFiles}
+
+@example
+```js
+import {isIgnoredByIgnoreFilesSync} from 'globby';
+
+const isIgnored = isIgnoredByIgnoreFilesSync('**\/.gitignore');
+
+console.log(isIgnored('some/file'));
+```
+*/
 export function isIgnoredByIgnoreFilesSync(
 	patterns: string | readonly string[],
 	options?: Options

--- a/index.d.ts
+++ b/index.d.ts
@@ -205,3 +205,43 @@ export function isGitIgnored(options?: GitignoreOptions): Promise<GlobbyFilterFu
 export function isGitIgnoredSync(options?: GitignoreOptions): GlobbyFilterFunction;
 
 export function convertPathToPattern(source: string): FastGlob.Pattern;
+
+
+/**
+ * Check if a path is ignored by the ignore files.
+ * @param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
+ * @param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
+ *
+ * @returns A filter function indicating whether a given path is ignored via the ignore files.
+ *
+ * @example
+ * ```
+ * import {isIgnoredByIgnoreFiles} from 'globby';
+ *
+ * const isIgnored = await isIgnoredByIgnoreFiles('**\/.gitignore');
+ *
+ * console.log(isIgnored('some/file'));
+ * ```
+ */
+export function isIgnoredByIgnoreFiles(
+	patterns: string | readonly string[],
+	options?: Options
+): Promise<GlobbyFilterFunction>;
+
+/**
+ * Check if a path is ignored by the ignore files.
+ * @see {@link isIgnoredByIgnoreFiles}
+ *
+ * @example
+ * ```js
+ * import {isIgnoredByIgnoreFilesSync} from 'globby';
+ *
+ * const isIgnored = isIgnoredByIgnoreFilesSync('**\/.gitignore');
+ *
+ * console.log(isIgnored('some/file'));
+ * ```
+ */
+export function isIgnoredByIgnoreFilesSync(
+	patterns: string | readonly string[],
+	options?: Options
+): GlobbyFilterFunction;

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,10 +208,12 @@ export function convertPathToPattern(source: string): FastGlob.Pattern;
 
 /**
 Check if a path is ignored by the ignore files.
+
 @param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 @param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
-
 @returns A filter function indicating whether a given path is ignored via the ignore files.
+
+This is a more generic form of the `isGitIgnored` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
 
 @example
 ```
@@ -229,10 +231,17 @@ export function isIgnoredByIgnoreFiles(
 
 /**
 Check if a path is ignored by the ignore files.
+
+@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
+@param options - See the [`fast-glob` options](https://github.com/mrmlnc/fast-glob#options-3) in addition to the ones in this package.
+@returns A filter function indicating whether a given path is ignored via the ignore files.
+
+This is a more generic form of the `isGitIgnored` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
+
 @see {@link isIgnoredByIgnoreFiles}
 
 @example
-```js
+```
 import {isIgnoredByIgnoreFilesSync} from 'globby';
 
 const isIgnored = isIgnoredByIgnoreFilesSync('**\/.gitignore');

--- a/index.d.ts
+++ b/index.d.ts
@@ -206,7 +206,6 @@ export function isGitIgnoredSync(options?: GitignoreOptions): GlobbyFilterFuncti
 
 export function convertPathToPattern(source: string): FastGlob.Pattern;
 
-
 /**
  * Check if a path is ignored by the ignore files.
  * @param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).

--- a/index.js
+++ b/index.js
@@ -259,6 +259,8 @@ export const generateGlobTasksSync = normalizeArgumentsSync(generateTasksSync);
 export {
 	isGitIgnored,
 	isGitIgnoredSync,
+	isIgnoredByIgnoreFiles,
+	isIgnoredByIgnoreFilesSync
 } from './ignore.js';
 
 export const {convertPathToPattern} = fastGlob;

--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ export {
 	isGitIgnored,
 	isGitIgnoredSync,
 	isIgnoredByIgnoreFiles,
-	isIgnoredByIgnoreFilesSync
+	isIgnoredByIgnoreFilesSync,
 } from './ignore.js';
 
 export const {convertPathToPattern} = fastGlob;

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ Takes `cwd?: URL | string` as options.
 
 ### isIgnoredByIgnoreFiles(patterns, options?)
 
-Returns a `Promise<(path: URL | string) => boolean>` indicating whether a given path is ignored via an ignore file.
+Returns a `Promise<(path: URL | string) => boolean>` indicating whether a given path is ignored via the ignore files.
 
 This is a more generic form of the `isGitIgnored` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
 
@@ -176,7 +176,7 @@ console.log(isIgnored('some/file'));
 
 ### isIgnoredByIgnoreFilesSync(patterns, options?)
 
-Returns a `(path: URL | string) => boolean` indicating whether a given path is ignored via an ignore file.
+Returns a `(path: URL | string) => boolean` indicating whether a given path is ignored via the ignore files.
 
 This is a more generic form of the `isGitIgnoredSync` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
 

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,39 @@ Returns a `(path: URL | string) => boolean` indicating whether a given path is i
 
 Takes `cwd?: URL | string` as options.
 
+
+### isIgnoredByIgnoreFiles(patterns, options?)
+
+Returns a `Promise<(path: URL | string) => boolean>` indicating whether a given path is ignored via an ignore file.
+
+This is a more generic form of the `isGitIgnored` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
+
+Takes `cwd?: URL | string` as options.
+
+```js
+import {isIgnoredByIgnoreFiles} from 'globby';
+
+const isIgnored = await isIgnoredByIgnoreFiles("**/.gitignore");
+
+console.log(isIgnored('some/file'));
+```
+
+### isIgnoredByIgnoreFilesSync(patterns, options?)
+
+Returns a `(path: URL | string) => boolean` indicating whether a given path is ignored via an ignore file.
+
+This is a more generic form of the `isGitIgnoredSync` function, allowing you to find ignore files with a [compatible syntax](http://git-scm.com/docs/gitignore). For instance, this works with Babel's `.babelignore`, Prettier's `.prettierignore`, or ESLint's `.eslintignore` files.
+
+Takes `cwd?: URL | string` as options.
+
+```js
+import {isIgnoredByIgnoreFilesSync} from 'globby';
+
+const isIgnored = isIgnoredByIgnoreFilesSync("**/.gitignore");
+
+console.log(isIgnored('some/file'));
+```
+
 ## Globbing patterns
 
 Just a quick overview.


### PR DESCRIPTION
I am developing a feature to dynamically monitor folder changes. There is a file similar to `. gitignore` that needs to determine whether it is ignored after the file adds. This requires the use of the underlying methods `isIgnoredByIgnoreFiles` or `isIgnoredByIgnoreFilesSync` that are not exposed.