### PR TITLE
Fix `gitignore` ignoring an entire checkout under an anchored ancestor path

### DIFF
--- a/tests/globby.js
+++ b/tests/globby.js
@@ -937,6 +937,34 @@ test('gitignore option with absolute option', async t => {
 	t.false(result.includes('node_modules'));
 });
 
+test('gitignore option with absolute option does not over-ignore a checkout under an anchored ancestor', async t => {
+	// An anchored pattern like `/foo` is repo-root-relative, so git only ignores `<repo>/foo`.
+	// With `absolute: true` the pattern must not be matched against the absolute candidate
+	// paths, otherwise a checkout that itself lives under a matching `/foo/…` directory is
+	// pruned entirely. Anchor the pattern to the checkout's own leading path segment to
+	// recreate that: only `<repo>/<segment>` should be ignored, never everything.
+	const repository = createTemporaryGitRepository();
+	const segment = path.resolve(repository).split(path.sep).find(Boolean);
+
+	fs.writeFileSync(path.join(repository, '.gitignore'), `/${segment}\n`, 'utf8');
+	fs.writeFileSync(path.join(repository, 'a.md'), '', 'utf8');
+	fs.writeFileSync(path.join(repository, 'b.md'), '', 'utf8');
+	fs.mkdirSync(path.join(repository, segment));
+	fs.writeFileSync(path.join(repository, segment, 'ignored.md'), '', 'utf8');
+
+	const result = await runGlobby(t, '**/*.md', {
+		cwd: repository,
+		absolute: true,
+		dot: true,
+		gitignore: true,
+	});
+
+	t.deepEqual(
+		result.map(file => path.relative(repository, file)).sort(),
+		['a.md', 'b.md'],
+	);
+});
+
 test('gitignore option and objectMode option', async t => {
 	const result = await runGlobby(t, 'fixtures/gitignore/*', {gitignore: true, objectMode: true});
 	t.is(result.length, 1);

--- a/utilities.js
+++ b/utilities.js
@@ -375,7 +375,13 @@ export const convertPatternsForFastGlob = (patterns, usingGitRoot, normalizeDire
 			break; // Early exit on first negation
 		}
 
-		result.push(normalizeDirectoryPatternForFastGlob(pattern));
+		// `.gitignore` patterns are relative to the repo root, but an anchored pattern like
+		// `/foo` looks like an absolute path to globby's directory-to-glob expansion, which
+		// resolves it against the real filesystem. When the checkout lives under a matching
+		// `/foo/…` path, `/foo` is a real ancestor directory and expands to `/foo/**`, which
+		// ignores the whole tree. Drop the leading slash so the pattern stays anchored to the
+		// cwd instead, letting fast-glob still skip the directory during traversal.
+		result.push(normalizeDirectoryPatternForFastGlob(pattern).replace(/^\//, ''));
 	}
 
 	return hasNegations ? [] : result;


### PR DESCRIPTION
Closes #278

Calling globby with `{gitignore: true, absolute: true}` returns **zero files** when the project's absolute path contains a path segment matching an anchored `.gitignore` pattern (a pattern with a leading `/`, e.g. `/build`). `git check-ignore` reports those files as *not* ignored, so globby diverges from git.

### Reproduction

```sh
mkdir -p /tmp/globby-bug && cd /tmp/globby-bug
npm i globby
printf '/tmp\n' > .gitignore     # anchored: git only ignores <repo>/tmp
printf '# readme\n' > readme.md
node --input-type=module -e "import {globby} from 'globby'; console.log(await globby('*.md', {cwd: '/tmp/globby-bug', gitignore: true, absolute: true}))"
```

```
# globby 16.2.0 → []                              (bug: whole checkout ignored)
# this PR       → [ '/tmp/globby-bug/readme.md' ]  (correct — matches git)
```

The checkout lives under `/tmp`, so the anchored `/tmp` — which git scopes to `<repo>/tmp` only — is the trigger. (`cwd` is passed explicitly so the path stays `/tmp/...` on macOS, where `cd /tmp` resolves to `/private/tmp`.)

### Cause

An anchored pattern like `/foo` is relative to the repository root, so git only ignores `<repo>/foo`. As a traversal optimization, globby forwards `.gitignore` patterns to fast-glob's `ignore` and expands directory patterns to globs. Because `/foo` looks like an absolute path, that expansion resolves it against the real filesystem — and when the checkout lives under a matching `/foo/…` directory, `/foo` is a real ancestor directory that expands to `/foo/**`, which matches every absolute candidate path and prunes the whole tree.

Real-world trigger: markdownlint-cli2 globs with `{gitignore: true, absolute: true}`; on a CI runner that checks out under `/build/…`, `/home/…` or `/workspace/…` with a matching anchored line, it silently lints 0 files and passes.

### Fix

Drop the leading slash when handing anchored patterns to fast-glob, so they stay anchored to the cwd instead of the filesystem root. fast-glob still skips the directory during traversal (the optimization is kept), and globby's cwd-relative predicate continues to enforce the exact gitignore semantics. Stripping happens *after* directory normalization, so `/foo/` stays anchored (`foo/**`) rather than being turned into a recursive `**/foo/**`. Un-anchored patterns and the negation / git-root short-circuits are unchanged.

### Test

Adds a regression test (covering `globby`, `globbySync` and `globbyStream` via the shared helper) that builds a repo whose leading path segment matches an anchored pattern and asserts only `<repo>/<segment>` is ignored — not everything, and not a same-named directory nested deeper.